### PR TITLE
fix: use interceptReadableStream + decouple getHyperDXHTTPInstrumentationConfig

### DIFF
--- a/.changeset/early-bikes-remember.md
+++ b/.changeset/early-bikes-remember.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/node-opentelemetry': patch
+---
+
+fix: pipe readable stream bug (advanced network capture)

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -30,3 +30,5 @@ jobs:
         run: yarn ci:build
       - name: Run lint + type check
         run: yarn ci:lint
+      - name: Run unit tests
+        run: yarn ci:unit

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "ci:build": "npx nx run-many --target=build",
-    "ci:test": "npx nx run-many --target=test",
+    "ci:unit": "npx nx run-many --target=ci:unit",
     "ci:lint": "npx nx run-many --target=ci:lint",
     "release": "npx nx run-many --target=build && yarn changeset publish && git push --follow-tags",
     "prepare": "husky install"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -35,7 +35,7 @@
     "build:watch": "rollup --config rollup.config.ts --configPlugin typescript -w",
     "lint": "eslint . --ext .ts --ext .mts",
     "ci:lint": "yarn lint && yarn tsc --noEmit",
-    "test": "jest --coverage",
+    "ci:unit": "jest --coverage --ci",
     "prettier": "prettier --config .prettierrc --write .",
     "test:watch": "jest --watch"
   }

--- a/packages/node-logger/package.json
+++ b/packages/node-logger/package.json
@@ -26,9 +26,8 @@
     "build:watch": "tsc -w -p tsconfig.json",
     "lint": "eslint . --ext .ts --ext .mts",
     "ci:lint": "yarn lint && yarn tsc --noEmit",
-    "test": "jest --coverage",
-    "prettier": "prettier --config .prettierrc --write .",
-    "test:watch": "jest --watch"
+    "dev:unit": "jest --watch",
+    "prettier": "prettier --config .prettierrc --write ."
   },
   "dependencies": {
     "@nestjs/common": "^9.4.2",

--- a/packages/node-opentelemetry/README.md
+++ b/packages/node-opentelemetry/README.md
@@ -162,7 +162,6 @@ const { RemixInstrumentation } = require('opentelemetry-instrumentation-remix');
 
 initSDK({
   consoleCapture: true, // optional, default: true
-  advancedNetworkCapture: true, // optional, default: false
   additionalInstrumentations: [new RemixInstrumentation()], // your custom instrumentations here
 });
 ```
@@ -190,7 +189,7 @@ To attach trace id to console logs, you can set `HDX_NODE_BETA_MODE` environment
 export HDX_NODE_BETA_MODE=1
 ```
 
-#### Advanced Network Capture
+#### Advanced Network Capture (BETA)
 
 By enabling advanced network capture, the SDK will additionally capture full HTTP request/response headers
 and bodies for all inbound/outbound HTTP requests, to help with more in-depth request debugging.

--- a/packages/node-opentelemetry/README.md
+++ b/packages/node-opentelemetry/README.md
@@ -102,7 +102,6 @@ import { initSDK } from '@hyperdx/node-opentelemetry';
 
 initSDK({
   consoleCapture: true, // optional, default: true
-  advancedNetworkCapture: true, // optional, default: false
   additionalInstrumentations: [], // optional, default: []
 });
 

--- a/packages/node-opentelemetry/__tests__/instrumentations.test.ts
+++ b/packages/node-opentelemetry/__tests__/instrumentations.test.ts
@@ -202,8 +202,15 @@ describe('instrumentations', () => {
 
         interceptReadableStream(mockEventStream, pt);
 
+        const dataFromCustomPT = [];
         const dataFromDownSreamReader = [];
+        // pipe another passThrough
+        const customPT = new PassThrough();
+        customPT.on('data', (data) => {
+          dataFromCustomPT.push(data.toString());
+        });
         setTimeout(async () => {
+          mockEventStream.pipe(customPT);
           mockEventStream.resume();
           for await (const data of mockEventStream) {
             dataFromDownSreamReader.push(data);
@@ -218,6 +225,11 @@ describe('instrumentations', () => {
         });
 
         expect(dataFromPT).toEqual([
+          '{"message":"foo 1"}',
+          '{"message":"foo 2"}',
+          '{"message":"foo 3"}',
+        ]);
+        expect(dataFromCustomPT).toEqual([
           '{"message":"foo 1"}',
           '{"message":"foo 2"}',
           '{"message":"foo 3"}',

--- a/packages/node-opentelemetry/__tests__/instrumentations.test.ts
+++ b/packages/node-opentelemetry/__tests__/instrumentations.test.ts
@@ -217,30 +217,29 @@ describe('instrumentations', () => {
 
         interceptReadableStream(mockEventStream, pt);
 
-        const dataFromDownSreamReader = [];
-        mockEventStream.on('data', (data) => {
-          dataFromDownSreamReader.push(data);
+        const customPT = new PassThrough();
+        const dataFromCustomPT = [];
+        customPT.on('data', (data) => {
+          dataFromCustomPT.push(data.toString());
         });
+
+        setTimeout(() => {
+          mockEventStream.pipe(customPT);
+        }, 10);
 
         // the stream should not start flowing
         expect(dataFromPT.length).toEqual(0);
-        expect(dataFromDownSreamReader.length).toEqual(0);
+        expect(dataFromCustomPT.length).toEqual(0);
 
-        mockEventStream.resume();
-
-        // wait for the stream to end
-        await new Promise((resolve) => {
-          mockEventStream.on('end', () => {
-            resolve(null);
-          });
-        });
+        // wait for the customPT to be piped
+        await new Promise((r) => setTimeout(r, 1000));
 
         expect(dataFromPT).toEqual([
           '{"message":"foo 1"}',
           '{"message":"foo 2"}',
           '{"message":"foo 3"}',
         ]);
-        expect(dataFromDownSreamReader).toEqual([
+        expect(dataFromCustomPT).toEqual([
           '{"message":"foo 1"}',
           '{"message":"foo 2"}',
           '{"message":"foo 3"}',

--- a/packages/node-opentelemetry/__tests__/instrumentations.test.ts
+++ b/packages/node-opentelemetry/__tests__/instrumentations.test.ts
@@ -7,8 +7,6 @@ import {
   splitCommaSeparatedStrings,
 } from '../src/instrumentations/http';
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 describe('instrumentations', () => {
   describe('console', () => {
     it('should parse console args', () => {

--- a/packages/node-opentelemetry/package.json
+++ b/packages/node-opentelemetry/package.json
@@ -27,8 +27,8 @@
     "build:watch": "tsc -w -p tsconfig.json",
     "lint": "eslint . --ext .ts --ext .mts",
     "ci:lint": "yarn lint && yarn tsc --noEmit",
-    "test": "jest --coverage",
-    "dev:test": "jest --watchAll",
+    "dev:unit": "jest --watchAll",
+    "ci:unit": "jest --coverage --ci",
     "prettier": "prettier --config .prettierrc --write ."
   },
   "dependencies": {

--- a/packages/node-opentelemetry/src/instrumentations/http.ts
+++ b/packages/node-opentelemetry/src/instrumentations/http.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import zlib from 'zlib';
-import { PassThrough } from 'stream';
+import { PassThrough, Readable } from 'stream';
 
 import { Span } from '@opentelemetry/api';
 import { headerCapture } from '@opentelemetry/instrumentation-http';
@@ -65,13 +65,12 @@ export const getShouldRecordBody =
     return true;
   };
 
-export const interceptReadableStream = (
-  stream: NodeJS.ReadableStream,
-  pt: PassThrough,
-) => {
+export const interceptReadableStream = (stream: Readable, pt: PassThrough) => {
+  const originalState = stream.readableFlowing;
   stream.pipe(pt);
   // hack: so the pipe doesn't start flowing
-  (stream as any).readableFlowing = null;
+  // @ts-ignore (readonly)
+  stream.readableFlowing = originalState;
   return stream;
 };
 

--- a/packages/node-opentelemetry/src/instrumentations/http.ts
+++ b/packages/node-opentelemetry/src/instrumentations/http.ts
@@ -68,7 +68,9 @@ export const getShouldRecordBody =
 export const interceptReadableStream = (stream: Readable, pt: PassThrough) => {
   const originalState = stream.readableFlowing;
   stream.pipe(pt);
-  // hack: so the pipe doesn't start flowing
+  // FIXME: this might not work properly for 'readable' event handler
+  // bacause the state is becoming 'true' after detaching the handler
+  // and the pipe would stream the data and cause data loss
   // @ts-ignore (readonly)
   stream.readableFlowing = originalState;
   return stream;

--- a/packages/node-opentelemetry/src/instrumentations/http.ts
+++ b/packages/node-opentelemetry/src/instrumentations/http.ts
@@ -65,6 +65,248 @@ export const getShouldRecordBody =
     return true;
   };
 
+export const interceptReadableStream = (
+  stream: NodeJS.ReadableStream,
+  pt: PassThrough,
+) => {
+  const oldOn = stream.on.bind(stream);
+  let isPiped = false;
+  stream.on = (event: string, listener: (...args: any[]) => void) => {
+    oldOn(event, listener);
+    // WARNING: only pipe the stream if the user has registered a listener for the 'data' or 'readable' event
+    if ((event === 'readable' || event === 'data') && !isPiped) {
+      isPiped = true;
+      stream.pipe(pt);
+    }
+    return stream;
+  };
+  return stream;
+};
+
+export const _handleHttpOutgoingClientRequest = (
+  request: http.ClientRequest,
+  span: Span,
+  shouldRecordBody: (body: string) => boolean,
+  httpCaptureHeadersClientRequest?: string,
+) => {
+  /* Capture Headers */
+  try {
+    const headers =
+      splitCommaSeparatedStrings(httpCaptureHeadersClientRequest) ??
+      request.getRawHeaderNames();
+    headerCapture('request', headers)(span, (header) =>
+      request.getHeader(header),
+    );
+  } catch (e) {
+    hdx(`error parsing outgoing-request headers in requestHook: ${e}`);
+  }
+
+  /* Capture Body */
+  const chunks = [];
+  const oldWrite = request.write.bind(request);
+  request.write = (data: any) => {
+    try {
+      if (typeof data === 'string') {
+        chunks.push(Buffer.from(data));
+      } else {
+        chunks.push(data);
+      }
+    } catch (e) {
+      hdx(`error in request.write: ${e}`);
+    }
+    return oldWrite(data);
+  };
+  const oldEnd = request.end.bind(request);
+  request.end = (data: any) => {
+    try {
+      if (data) {
+        if (typeof data === 'string') {
+          chunks.push(Buffer.from(data));
+        } else {
+          chunks.push(data);
+        }
+      }
+      if (chunks.length > 0) {
+        const body = Buffer.concat(chunks).toString('utf8');
+        if (shouldRecordBody(body)) {
+          span.setAttribute('http.request.body', body);
+        } else {
+          span.setAttribute('http.request.body', SENSITIVE_DATA_SUBSTITUTE);
+        }
+      }
+    } catch (e) {
+      hdx(`error in request.end: ${e}`);
+    }
+    return oldEnd(data);
+  };
+};
+
+export const _handleHttpIncomingServerRequest = (
+  request: http.IncomingMessage,
+  span: Span,
+  shouldRecordBody: (body: string) => boolean,
+  httpCaptureHeadersServerRequest?: string,
+) => {
+  /* Capture Headers */
+  try {
+    const headers =
+      splitCommaSeparatedStrings(httpCaptureHeadersServerRequest) ??
+      request.headers;
+    headerCapture('request', Object.keys(headers))(
+      span,
+      (header) => headers[header],
+    );
+  } catch (e) {
+    hdx(`error parsing incoming-request headers in requestHook: ${e}`);
+  }
+
+  /* Capture Body */
+  const chunks = [];
+  const pt = new PassThrough();
+  pt.on('data', (chunk) => {
+    try {
+      if (typeof chunk === 'string') {
+        chunks.push(Buffer.from(chunk));
+      } else {
+        chunks.push(chunk);
+      }
+    } catch (e) {
+      hdx(`error in request.on('data'): ${e}`);
+    }
+  }).on('end', () => {
+    try {
+      if (chunks.length > 0) {
+        const body = Buffer.concat(chunks).toString('utf8');
+        if (shouldRecordBody(body)) {
+          span.setAttribute('http.request.body', body);
+        } else {
+          span.setAttribute('http.request.body', SENSITIVE_DATA_SUBSTITUTE);
+        }
+      }
+    } catch (e) {
+      hdx(`error in request.on('end'): ${e}`);
+    }
+  });
+  interceptReadableStream(request, pt);
+};
+
+export const _handleHttpIncomingServerResponse = (
+  response: http.ServerResponse,
+  span: Span,
+  shouldRecordBody: (body: string) => boolean,
+  httpCaptureHeadersServerResponse?: string,
+) => {
+  /* Capture Body */
+  const chunks = [];
+  const oldWrite = response.write.bind(response);
+  response.write = (data: any) => {
+    try {
+      if (typeof data === 'string') {
+        chunks.push(Buffer.from(data));
+      } else {
+        chunks.push(data);
+      }
+    } catch (e) {
+      hdx(`error in response.write: ${e}`);
+    }
+    return oldWrite(data);
+  };
+  const oldEnd = response.end.bind(response);
+  response.end = (data: any) => {
+    try {
+      if (data) {
+        if (typeof data === 'string') {
+          chunks.push(Buffer.from(data));
+        } else {
+          chunks.push(data);
+        }
+      }
+      if (chunks.length > 0) {
+        const buffers = Buffer.concat(chunks);
+        let body = buffers.toString('utf8');
+        const isGzip = response.getHeader('content-encoding') === 'gzip';
+        if (isGzip) {
+          body = zlib.gunzipSync(buffers).toString('utf8');
+        }
+        if (shouldRecordBody(body)) {
+          span.setAttribute('http.response.body', body);
+        } else {
+          span.setAttribute('http.response.body', SENSITIVE_DATA_SUBSTITUTE);
+        }
+      }
+    } catch (e) {
+      hdx(`error in response.end: ${e}`);
+    }
+
+    /* Capture Headers */
+    try {
+      const headers =
+        splitCommaSeparatedStrings(httpCaptureHeadersServerResponse) ??
+        response.getHeaderNames();
+      headerCapture('response', headers)(span, (header) =>
+        response.getHeader(header),
+      );
+    } catch (e) {
+      hdx(`error parsing incoming-response headers in responseHook: ${e}`);
+    }
+    return oldEnd(data);
+  };
+};
+
+export const _handleHttpOutgoingClientResponse = (
+  response: http.IncomingMessage,
+  span: Span,
+  shouldRecordBody: (body: string) => boolean,
+  httpCaptureHeadersClientResponse?: string,
+) => {
+  /* Capture Headers */
+  try {
+    const headers =
+      splitCommaSeparatedStrings(httpCaptureHeadersClientResponse) ??
+      response.headers;
+    headerCapture('response', Object.keys(headers))(
+      span,
+      (header) => headers[header],
+    );
+  } catch (e) {
+    hdx(`error parsing outgoing-response headers in responseHook: ${e}`);
+  }
+
+  /* Capture Body */
+  const chunks = [];
+  const pt = new PassThrough();
+  pt.on('data', (chunk) => {
+    try {
+      if (typeof chunk === 'string') {
+        chunks.push(Buffer.from(chunk));
+      } else {
+        chunks.push(chunk);
+      }
+    } catch (e) {
+      hdx(`error in response.on('data'): ${e}`);
+    }
+  }).on('end', () => {
+    try {
+      if (chunks.length > 0) {
+        const buffers = Buffer.concat(chunks);
+        let body = buffers.toString('utf8');
+        const isGzip = response.headers['content-encoding'] === 'gzip';
+        if (isGzip) {
+          body = zlib.gunzipSync(buffers).toString('utf8');
+        }
+        if (shouldRecordBody(body)) {
+          span.setAttribute('http.response.body', body);
+        } else {
+          span.setAttribute('http.response.body', SENSITIVE_DATA_SUBSTITUTE);
+        }
+      }
+    } catch (e) {
+      hdx(`error in response.on('end'): ${e}`);
+    }
+  });
+  interceptReadableStream(response, pt);
+};
+
 export const getHyperDXHTTPInstrumentationConfig = ({
   httpCaptureBodyKeywordsFilter,
   httpCaptureHeadersClientRequest,
@@ -86,105 +328,20 @@ export const getHyperDXHTTPInstrumentationConfig = ({
     ) => {
       if (request instanceof http.ClientRequest) {
         // outgoing request (client)
-        /* Capture Headers */
-        try {
-          const headers =
-            splitCommaSeparatedStrings(httpCaptureHeadersClientRequest) ??
-            request.getRawHeaderNames();
-          headerCapture('request', headers)(span, (header) =>
-            request.getHeader(header),
-          );
-        } catch (e) {
-          hdx(`error parsing outgoing-request headers in requestHook: ${e}`);
-        }
-
-        /* Capture Body */
-        const chunks = [];
-        const oldWrite = request.write.bind(request);
-        request.write = (data: any) => {
-          try {
-            if (typeof data === 'string') {
-              chunks.push(Buffer.from(data));
-            } else {
-              chunks.push(data);
-            }
-          } catch (e) {
-            hdx(`error in request.write: ${e}`);
-          }
-          return oldWrite(data);
-        };
-        const oldEnd = request.end.bind(request);
-        request.end = (data: any) => {
-          try {
-            if (data) {
-              if (typeof data === 'string') {
-                chunks.push(Buffer.from(data));
-              } else {
-                chunks.push(data);
-              }
-            }
-            if (chunks.length > 0) {
-              const body = Buffer.concat(chunks).toString('utf8');
-              if (shouldRecordBody(body)) {
-                span.setAttribute('http.request.body', body);
-              } else {
-                span.setAttribute(
-                  'http.request.body',
-                  SENSITIVE_DATA_SUBSTITUTE,
-                );
-              }
-            }
-          } catch (e) {
-            hdx(`error in request.end: ${e}`);
-          }
-          return oldEnd(data);
-        };
+        _handleHttpOutgoingClientRequest(
+          request,
+          span,
+          shouldRecordBody,
+          httpCaptureHeadersClientRequest,
+        );
       } else {
         // incoming request (server)
-        /* Capture Headers */
-        try {
-          const headers =
-            splitCommaSeparatedStrings(httpCaptureHeadersServerRequest) ??
-            request.headers;
-          headerCapture('request', Object.keys(headers))(
-            span,
-            (header) => headers[header],
-          );
-        } catch (e) {
-          hdx(`error parsing incoming-request headers in requestHook: ${e}`);
-        }
-
-        /* Capture Body */
-        const chunks = [];
-        const pt = new PassThrough();
-        pt.on('data', (chunk) => {
-          try {
-            if (typeof chunk === 'string') {
-              chunks.push(Buffer.from(chunk));
-            } else {
-              chunks.push(chunk);
-            }
-          } catch (e) {
-            hdx(`error in request.on('data'): ${e}`);
-          }
-        }).on('end', () => {
-          try {
-            if (chunks.length > 0) {
-              const body = Buffer.concat(chunks).toString('utf8');
-              if (shouldRecordBody(body)) {
-                span.setAttribute('http.request.body', body);
-              } else {
-                span.setAttribute(
-                  'http.request.body',
-                  SENSITIVE_DATA_SUBSTITUTE,
-                );
-              }
-            }
-          } catch (e) {
-            hdx(`error in request.on('end'): ${e}`);
-          }
-        });
-        request.pipe(pt);
+        _handleHttpIncomingServerRequest(
+          request,
+          span,
+          shouldRecordBody,
+          httpCaptureHeadersServerRequest,
+        );
       }
     },
     responseHook: (
@@ -193,118 +350,20 @@ export const getHyperDXHTTPInstrumentationConfig = ({
     ) => {
       if (response instanceof http.ServerResponse) {
         // incoming response (server)
-        /* Capture Body */
-        const chunks = [];
-        const oldWrite = response.write.bind(response);
-        response.write = (data: any) => {
-          try {
-            if (typeof data === 'string') {
-              chunks.push(Buffer.from(data));
-            } else {
-              chunks.push(data);
-            }
-          } catch (e) {
-            hdx(`error in response.write: ${e}`);
-          }
-          return oldWrite(data);
-        };
-        const oldEnd = response.end.bind(response);
-        response.end = (data: any) => {
-          try {
-            if (data) {
-              if (typeof data === 'string') {
-                chunks.push(Buffer.from(data));
-              } else {
-                chunks.push(data);
-              }
-            }
-            if (chunks.length > 0) {
-              const buffers = Buffer.concat(chunks);
-              let body = buffers.toString('utf8');
-              const isGzip = response.getHeader('content-encoding') === 'gzip';
-              if (isGzip) {
-                body = zlib.gunzipSync(buffers).toString('utf8');
-              }
-              if (shouldRecordBody(body)) {
-                span.setAttribute('http.response.body', body);
-              } else {
-                span.setAttribute(
-                  'http.response.body',
-                  SENSITIVE_DATA_SUBSTITUTE,
-                );
-              }
-            }
-          } catch (e) {
-            hdx(`error in response.end: ${e}`);
-          }
-
-          /* Capture Headers */
-          try {
-            const headers =
-              splitCommaSeparatedStrings(httpCaptureHeadersServerResponse) ??
-              response.getHeaderNames();
-            headerCapture('response', headers)(span, (header) =>
-              response.getHeader(header),
-            );
-          } catch (e) {
-            hdx(
-              `error parsing incoming-response headers in responseHook: ${e}`,
-            );
-          }
-          return oldEnd(data);
-        };
+        _handleHttpIncomingServerResponse(
+          response,
+          span,
+          shouldRecordBody,
+          httpCaptureHeadersServerResponse,
+        );
       } else {
-        // outgoing request (client)
-        /* Capture Headers */
-        try {
-          const headers =
-            splitCommaSeparatedStrings(httpCaptureHeadersClientResponse) ??
-            response.headers;
-          headerCapture('response', Object.keys(headers))(
-            span,
-            (header) => headers[header],
-          );
-        } catch (e) {
-          hdx(`error parsing outgoing-response headers in responseHook: ${e}`);
-        }
-
-        /* Capture Body */
-        const chunks = [];
-        const pt = new PassThrough();
-        pt.on('data', (chunk) => {
-          try {
-            if (typeof chunk === 'string') {
-              chunks.push(Buffer.from(chunk));
-            } else {
-              chunks.push(chunk);
-            }
-          } catch (e) {
-            hdx(`error in response.on('data'): ${e}`);
-          }
-        }).on('end', () => {
-          try {
-            if (chunks.length > 0) {
-              const buffers = Buffer.concat(chunks);
-              let body = buffers.toString('utf8');
-              const isGzip = response.headers['content-encoding'] === 'gzip';
-              if (isGzip) {
-                body = zlib.gunzipSync(buffers).toString('utf8');
-              }
-              if (shouldRecordBody(body)) {
-                span.setAttribute('http.response.body', body);
-              } else {
-                span.setAttribute(
-                  'http.response.body',
-                  SENSITIVE_DATA_SUBSTITUTE,
-                );
-              }
-            }
-          } catch (e) {
-            hdx(`error in response.on('end'): ${e}`);
-          }
-        });
-        // FIXME: this might cause issues with some libraries (ex: clickhouse/client)
-        // response.pipe(pt);
+        // outgoing response (client)
+        _handleHttpOutgoingClientResponse(
+          response,
+          span,
+          shouldRecordBody,
+          httpCaptureHeadersClientResponse,
+        );
       }
     },
   };

--- a/packages/node-opentelemetry/src/instrumentations/http.ts
+++ b/packages/node-opentelemetry/src/instrumentations/http.ts
@@ -69,17 +69,9 @@ export const interceptReadableStream = (
   stream: NodeJS.ReadableStream,
   pt: PassThrough,
 ) => {
-  const oldOn = stream.on.bind(stream);
-  let isPiped = false;
-  stream.on = (event: string, listener: (...args: any[]) => void) => {
-    oldOn(event, listener);
-    // WARNING: only pipe the stream if the user has registered a listener for the 'data' or 'readable' event
-    if ((event === 'readable' || event === 'data') && !isPiped) {
-      isPiped = true;
-      stream.pipe(pt);
-    }
-    return stream;
-  };
+  stream.pipe(pt);
+  // hack: so the pipe doesn't start flowing
+  (stream as any).readableFlowing = null;
   return stream;
 };
 


### PR DESCRIPTION
Try to fix ticket https://github.com/hyperdxio/hyperdx/issues/24.

Root cause:
When the downstream lib registers the listener in a separate event cycle, the SDK PassThrough interceptor will fire the 'data.on' event ahead, which leads the data to be dropped in downstream.