### PR TITLE
Feat refactor advanced network capture

### DIFF
--- a/examples/hello-node-express/index.js
+++ b/examples/hello-node-express/index.js
@@ -3,6 +3,8 @@ const { context, metrics, propagation, trace } = require('@opentelemetry/api');
 
 initSDK({
   // advancedNetworkCapture: true,
+  networkBodyCapture: false,
+  networkHeadersCapture: false,
   // betaMode: true,
   // consoleCapture: true,
 });

--- a/packages/node-opentelemetry/__tests__/packageJsonComp.test.ts
+++ b/packages/node-opentelemetry/__tests__/packageJsonComp.test.ts
@@ -1,0 +1,51 @@
+import { comparePackageVersions } from '../utils/comparison';
+
+describe('comparePackageJsonVersions', () => {
+  test('equal versions return true for ==', () => {
+    expect(comparePackageVersions('1.0.0', '==', '1.0.0')).toBe(true);
+  });
+
+  test('different versions return false for ==', () => {
+    expect(comparePackageVersions('1.0.0', '==', '1.0.1')).toBe(false);
+  });
+
+  test('higher version returns true for >', () => {
+    expect(comparePackageVersions('1.0.1', '>', '1.0.0')).toBe(true);
+  });
+
+  test('lower version returns false for >', () => {
+    expect(comparePackageVersions('1.0.0', '>', '1.0.1')).toBe(false);
+  });
+
+  test('higher version returns true for >= when versions are equal', () => {
+    expect(comparePackageVersions('1.0.0', '>=', '1.0.0')).toBe(true);
+  });
+
+  test('higher version returns true for >=', () => {
+    expect(comparePackageVersions('1.0.1', '>=', '1.0.0')).toBe(true);
+  });
+
+  test('lower version returns false for >=', () => {
+    expect(comparePackageVersions('1.0.0', '>=', '1.0.1')).toBe(false);
+  });
+
+  test('lower version returns true for <', () => {
+    expect(comparePackageVersions('1.0.0', '<', '1.0.1')).toBe(true);
+  });
+
+  test('higher version returns false for <', () => {
+    expect(comparePackageVersions('1.0.1', '<', '1.0.0')).toBe(false);
+  });
+
+  test('lower version returns true for <= when versions are equal', () => {
+    expect(comparePackageVersions('1.0.0', '<=', '1.0.0')).toBe(true);
+  });
+
+  test('lower version returns true for <=', () => {
+    expect(comparePackageVersions('1.0.0', '<=', '1.0.1')).toBe(true);
+  });
+
+  test('higher version returns false for <=', () => {
+    expect(comparePackageVersions('1.0.1', '<=', '1.0.0')).toBe(false);
+  });
+});

--- a/packages/node-opentelemetry/src/instrumentations/http.ts
+++ b/packages/node-opentelemetry/src/instrumentations/http.ts
@@ -80,158 +80,131 @@ export const _handleHttpOutgoingClientRequest = (
   request: http.ClientRequest,
   span: Span,
   shouldRecordBody: (body: string) => boolean,
+  networkHeadersCapture: boolean,
+  networkBodyCapture: boolean,
   httpCaptureHeadersClientRequest?: string,
 ) => {
   /* Capture Headers */
-  try {
-    const headers =
-      splitCommaSeparatedStrings(httpCaptureHeadersClientRequest) ??
-      request.getRawHeaderNames();
-    headerCapture('request', headers)(span, (header) =>
-      request.getHeader(header),
-    );
-  } catch (e) {
-    hdx(`error parsing outgoing-request headers in requestHook: ${e}`);
+  if (networkHeadersCapture) {
+    try {
+      const headers =
+        splitCommaSeparatedStrings(httpCaptureHeadersClientRequest) ??
+        request.getRawHeaderNames();
+      headerCapture('request', headers)(span, (header) =>
+        request.getHeader(header),
+      );
+    } catch (e) {
+      hdx(`error parsing outgoing-request headers in requestHook: ${e}`);
+    }
   }
 
   /* Capture Body */
-  const chunks = [];
-  const oldWrite = request.write.bind(request);
-  request.write = (data: any) => {
-    try {
-      if (typeof data === 'string') {
-        chunks.push(Buffer.from(data));
-      } else {
-        chunks.push(data);
-      }
-    } catch (e) {
-      hdx(`error in request.write: ${e}`);
-    }
-    return oldWrite(data);
-  };
-  const oldEnd = request.end.bind(request);
-  request.end = (data: any) => {
-    try {
-      if (data) {
+  if (networkBodyCapture) {
+    const chunks = [];
+    const oldWrite = request.write.bind(request);
+    request.write = (data: any) => {
+      try {
         if (typeof data === 'string') {
           chunks.push(Buffer.from(data));
         } else {
           chunks.push(data);
         }
+      } catch (e) {
+        hdx(`error in request.write: ${e}`);
       }
-      if (chunks.length > 0) {
-        const body = Buffer.concat(chunks).toString('utf8');
-        if (shouldRecordBody(body)) {
-          span.setAttribute('http.request.body', body);
-        } else {
-          span.setAttribute('http.request.body', SENSITIVE_DATA_SUBSTITUTE);
+      return oldWrite(data);
+    };
+    const oldEnd = request.end.bind(request);
+    request.end = (data: any) => {
+      try {
+        if (data) {
+          if (typeof data === 'string') {
+            chunks.push(Buffer.from(data));
+          } else {
+            chunks.push(data);
+          }
         }
+        if (chunks.length > 0) {
+          const body = Buffer.concat(chunks).toString('utf8');
+          if (shouldRecordBody(body)) {
+            span.setAttribute('http.request.body', body);
+          } else {
+            span.setAttribute('http.request.body', SENSITIVE_DATA_SUBSTITUTE);
+          }
+        }
+      } catch (e) {
+        hdx(`error in request.end: ${e}`);
       }
-    } catch (e) {
-      hdx(`error in request.end: ${e}`);
-    }
-    return oldEnd(data);
-  };
+      return oldEnd(data);
+    };
+  }
 };
 
 export const _handleHttpIncomingServerRequest = (
   request: http.IncomingMessage,
   span: Span,
   shouldRecordBody: (body: string) => boolean,
+  networkHeadersCapture: boolean,
+  networkBodyCapture: boolean,
   httpCaptureHeadersServerRequest?: string,
 ) => {
   /* Capture Headers */
-  try {
-    const headers =
-      splitCommaSeparatedStrings(httpCaptureHeadersServerRequest) ??
-      request.headers;
-    headerCapture('request', Object.keys(headers))(
-      span,
-      (header) => headers[header],
-    );
-  } catch (e) {
-    hdx(`error parsing incoming-request headers in requestHook: ${e}`);
+  if (networkHeadersCapture) {
+    try {
+      const headers =
+        splitCommaSeparatedStrings(httpCaptureHeadersServerRequest) ??
+        request.headers;
+      headerCapture('request', Object.keys(headers))(
+        span,
+        (header) => headers[header],
+      );
+    } catch (e) {
+      hdx(`error parsing incoming-request headers in requestHook: ${e}`);
+    }
   }
 
   /* Capture Body */
-  const chunks = [];
-  const pt = new PassThrough();
-  pt.on('data', (chunk) => {
-    try {
-      if (typeof chunk === 'string') {
-        chunks.push(Buffer.from(chunk));
-      } else {
-        chunks.push(chunk);
-      }
-    } catch (e) {
-      hdx(`error in request.on('data'): ${e}`);
-    }
-  }).on('end', () => {
-    try {
-      if (chunks.length > 0) {
-        const body = Buffer.concat(chunks).toString('utf8');
-        if (shouldRecordBody(body)) {
-          span.setAttribute('http.request.body', body);
+  if (networkBodyCapture) {
+    const chunks = [];
+    const pt = new PassThrough();
+    pt.on('data', (chunk) => {
+      try {
+        if (typeof chunk === 'string') {
+          chunks.push(Buffer.from(chunk));
         } else {
-          span.setAttribute('http.request.body', SENSITIVE_DATA_SUBSTITUTE);
+          chunks.push(chunk);
         }
+      } catch (e) {
+        hdx(`error in request.on('data'): ${e}`);
       }
-    } catch (e) {
-      hdx(`error in request.on('end'): ${e}`);
-    }
-  });
-  interceptReadableStream(request, pt);
+    }).on('end', () => {
+      try {
+        if (chunks.length > 0) {
+          const body = Buffer.concat(chunks).toString('utf8');
+          if (shouldRecordBody(body)) {
+            span.setAttribute('http.request.body', body);
+          } else {
+            span.setAttribute('http.request.body', SENSITIVE_DATA_SUBSTITUTE);
+          }
+        }
+      } catch (e) {
+        hdx(`error in request.on('end'): ${e}`);
+      }
+    });
+    interceptReadableStream(request, pt);
+  }
 };
 
 export const _handleHttpIncomingServerResponse = (
   response: http.ServerResponse,
   span: Span,
   shouldRecordBody: (body: string) => boolean,
+  networkHeadersCapture: boolean,
+  networkBodyCapture: boolean,
   httpCaptureHeadersServerResponse?: string,
 ) => {
-  /* Capture Body */
-  const chunks = [];
-  const oldWrite = response.write.bind(response);
-  response.write = (data: any) => {
-    try {
-      if (typeof data === 'string') {
-        chunks.push(Buffer.from(data));
-      } else {
-        chunks.push(data);
-      }
-    } catch (e) {
-      hdx(`error in response.write: ${e}`);
-    }
-    return oldWrite(data);
-  };
-  const oldEnd = response.end.bind(response);
-  response.end = (data: any) => {
-    try {
-      if (data) {
-        if (typeof data === 'string') {
-          chunks.push(Buffer.from(data));
-        } else {
-          chunks.push(data);
-        }
-      }
-      if (chunks.length > 0) {
-        const buffers = Buffer.concat(chunks);
-        let body = buffers.toString('utf8');
-        const isGzip = response.getHeader('content-encoding') === 'gzip';
-        if (isGzip) {
-          body = zlib.gunzipSync(buffers).toString('utf8');
-        }
-        if (shouldRecordBody(body)) {
-          span.setAttribute('http.response.body', body);
-        } else {
-          span.setAttribute('http.response.body', SENSITIVE_DATA_SUBSTITUTE);
-        }
-      }
-    } catch (e) {
-      hdx(`error in response.end: ${e}`);
-    }
-
-    /* Capture Headers */
+  /* Capture Headers */
+  if (networkHeadersCapture) {
     try {
       const headers =
         splitCommaSeparatedStrings(httpCaptureHeadersServerResponse) ??
@@ -242,78 +215,134 @@ export const _handleHttpIncomingServerResponse = (
     } catch (e) {
       hdx(`error parsing incoming-response headers in responseHook: ${e}`);
     }
-    return oldEnd(data);
-  };
+  }
+
+  /* Capture Body */
+  if (networkBodyCapture) {
+    const chunks = [];
+    const oldWrite = response.write.bind(response);
+    response.write = (data: any) => {
+      try {
+        if (typeof data === 'string') {
+          chunks.push(Buffer.from(data));
+        } else {
+          chunks.push(data);
+        }
+      } catch (e) {
+        hdx(`error in response.write: ${e}`);
+      }
+      return oldWrite(data);
+    };
+    const oldEnd = response.end.bind(response);
+    response.end = (data: any) => {
+      try {
+        if (data) {
+          if (typeof data === 'string') {
+            chunks.push(Buffer.from(data));
+          } else {
+            chunks.push(data);
+          }
+        }
+        if (chunks.length > 0) {
+          const buffers = Buffer.concat(chunks);
+          let body = buffers.toString('utf8');
+          const isGzip = response.getHeader('content-encoding') === 'gzip';
+          if (isGzip) {
+            body = zlib.gunzipSync(buffers).toString('utf8');
+          }
+          if (shouldRecordBody(body)) {
+            span.setAttribute('http.response.body', body);
+          } else {
+            span.setAttribute('http.response.body', SENSITIVE_DATA_SUBSTITUTE);
+          }
+        }
+      } catch (e) {
+        hdx(`error in response.end: ${e}`);
+      }
+      return oldEnd(data);
+    };
+  }
 };
 
 export const _handleHttpOutgoingClientResponse = (
   response: http.IncomingMessage,
   span: Span,
   shouldRecordBody: (body: string) => boolean,
+  networkHeadersCapture: boolean,
+  networkBodyCapture: boolean,
   httpCaptureHeadersClientResponse?: string,
 ) => {
   /* Capture Headers */
-  try {
-    const headers =
-      splitCommaSeparatedStrings(httpCaptureHeadersClientResponse) ??
-      response.headers;
-    headerCapture('response', Object.keys(headers))(
-      span,
-      (header) => headers[header],
-    );
-  } catch (e) {
-    hdx(`error parsing outgoing-response headers in responseHook: ${e}`);
+  if (networkHeadersCapture) {
+    try {
+      const headers =
+        splitCommaSeparatedStrings(httpCaptureHeadersClientResponse) ??
+        response.headers;
+      headerCapture('response', Object.keys(headers))(
+        span,
+        (header) => headers[header],
+      );
+    } catch (e) {
+      hdx(`error parsing outgoing-response headers in responseHook: ${e}`);
+    }
   }
 
   /* Capture Body */
-  const chunks = [];
-  const pt = new PassThrough();
-  pt.on('data', (chunk) => {
-    try {
-      if (typeof chunk === 'string') {
-        chunks.push(Buffer.from(chunk));
-      } else {
-        chunks.push(chunk);
-      }
-    } catch (e) {
-      hdx(`error in response.on('data'): ${e}`);
-    }
-  }).on('end', () => {
-    try {
-      if (chunks.length > 0) {
-        const buffers = Buffer.concat(chunks);
-        let body = buffers.toString('utf8');
-        const isGzip = response.headers['content-encoding'] === 'gzip';
-        if (isGzip) {
-          body = zlib.gunzipSync(buffers).toString('utf8');
-        }
-        if (shouldRecordBody(body)) {
-          span.setAttribute('http.response.body', body);
+  if (networkBodyCapture) {
+    const chunks = [];
+    const pt = new PassThrough();
+    pt.on('data', (chunk) => {
+      try {
+        if (typeof chunk === 'string') {
+          chunks.push(Buffer.from(chunk));
         } else {
-          span.setAttribute('http.response.body', SENSITIVE_DATA_SUBSTITUTE);
+          chunks.push(chunk);
         }
+      } catch (e) {
+        hdx(`error in response.on('data'): ${e}`);
       }
-    } catch (e) {
-      hdx(`error in response.on('end'): ${e}`);
-    }
-  });
-  interceptReadableStream(response, pt);
+    }).on('end', () => {
+      try {
+        if (chunks.length > 0) {
+          const buffers = Buffer.concat(chunks);
+          let body = buffers.toString('utf8');
+          const isGzip = response.headers['content-encoding'] === 'gzip';
+          if (isGzip) {
+            body = zlib.gunzipSync(buffers).toString('utf8');
+          }
+          if (shouldRecordBody(body)) {
+            span.setAttribute('http.response.body', body);
+          } else {
+            span.setAttribute('http.response.body', SENSITIVE_DATA_SUBSTITUTE);
+          }
+        }
+      } catch (e) {
+        hdx(`error in response.on('end'): ${e}`);
+      }
+    });
+    interceptReadableStream(response, pt);
+  }
 };
 
 export const getHyperDXHTTPInstrumentationConfig = ({
+  networkHeadersCapture,
+  networkBodyCapture,
   httpCaptureBodyKeywordsFilter,
   httpCaptureHeadersClientRequest,
   httpCaptureHeadersClientResponse,
   httpCaptureHeadersServerRequest,
   httpCaptureHeadersServerResponse,
 }: {
+  networkHeadersCapture: boolean;
+  networkBodyCapture: boolean;
   httpCaptureBodyKeywordsFilter?: string;
   httpCaptureHeadersClientRequest?: string;
   httpCaptureHeadersClientResponse?: string;
   httpCaptureHeadersServerRequest?: string;
   httpCaptureHeadersServerResponse?: string;
 }) => {
-  const shouldRecordBody = getShouldRecordBody(httpCaptureBodyKeywordsFilter);
+  const shouldRecordBody =
+    networkBodyCapture && getShouldRecordBody(httpCaptureBodyKeywordsFilter);
   return {
     requestHook: (
       span: Span,
@@ -325,6 +354,8 @@ export const getHyperDXHTTPInstrumentationConfig = ({
           request,
           span,
           shouldRecordBody,
+          networkHeadersCapture,
+          networkBodyCapture,
           httpCaptureHeadersClientRequest,
         );
       } else {
@@ -333,6 +364,8 @@ export const getHyperDXHTTPInstrumentationConfig = ({
           request,
           span,
           shouldRecordBody,
+          networkHeadersCapture,
+          networkBodyCapture,
           httpCaptureHeadersServerRequest,
         );
       }
@@ -347,6 +380,8 @@ export const getHyperDXHTTPInstrumentationConfig = ({
           response,
           span,
           shouldRecordBody,
+          networkHeadersCapture,
+          networkBodyCapture,
           httpCaptureHeadersServerResponse,
         );
       } else {
@@ -355,6 +390,8 @@ export const getHyperDXHTTPInstrumentationConfig = ({
           response,
           span,
           shouldRecordBody,
+          networkHeadersCapture,
+          networkBodyCapture,
           httpCaptureHeadersClientResponse,
         );
       }

--- a/packages/node-opentelemetry/src/otel.ts
+++ b/packages/node-opentelemetry/src/otel.ts
@@ -74,7 +74,7 @@ export const initSDK = (config: SDKConfig) => {
   if (config.advancedNetworkCapture) {
     if (comparePackageVersions(PKG_VERSION, '==', '0.6.1')) {
       console.warn(
-        `${LOG_PREFIX} Warning: The "advancedNetworkCapture" flag is available in version 0.0.1 but will be removed in future versions. Please consider using "networkHeadersCapture" and "networkBodyCapture" instead.`,
+        `${LOG_PREFIX} Warning: The "advancedNetworkCapture" flag is available in version 0.6.1 but will be removed in future versions. Please consider using "networkHeadersCapture" and "networkBodyCapture" instead.`,
       );
     } else if (comparePackageVersions(PKG_VERSION, '>', '0.6.1')) {
       throw new Error(

--- a/packages/node-opentelemetry/src/tracing.ts
+++ b/packages/node-opentelemetry/src/tracing.ts
@@ -8,9 +8,8 @@ const env = process.env;
 initSDK({
   betaMode: stringToBoolean(env.HDX_NODE_BETA_MODE),
   consoleCapture: stringToBoolean(env.HDX_NODE_CONSOLE_CAPTURE),
-  advancedNetworkCapture: stringToBoolean(
-    env.HDX_NODE_ADVANCED_NETWORK_CAPTURE,
-  ),
+  networkHeadersCapture: stringToBoolean(env.HDX_NODE_NETWORK_HEADER_CAPTURE),
+  networkBodyCapture: stringToBoolean(env.HDX_NODE_NETWORK_BODY_CAPTURE),
   stopOnTerminationSignals:
     stringToBoolean(env.HDX_NODE_STOP_ON_TERMINATION_SIGNALS) ?? true,
 });

--- a/packages/node-opentelemetry/utils/comparison.ts
+++ b/packages/node-opentelemetry/utils/comparison.ts
@@ -1,0 +1,24 @@
+/**
+ * Compare the version of package.json
+ */
+export function comparePackageVersions(
+  v1: string,
+  comparator: string,
+  v2: string,
+): boolean {
+  const v1parts = v1.split('.').map(Number);
+  const v2parts = v2.split('.').map(Number);
+  const maxLength = Math.max(v1parts.length, v2parts.length);
+
+  for (let i = 0; i < maxLength; i++) {
+    const v1part = v1parts[i] || 0;
+    const v2part = v2parts[i] || 0;
+
+    if (v1part === v2part) continue;
+
+    if (v1part > v2part) return comparator === '>' || comparator === '>=';
+    if (v1part < v2part) return comparator === '<' || comparator === '<=';
+  }
+
+  return comparator === '==' || comparator === '>=' || comparator === '<=';
+}


### PR DESCRIPTION
## Background

Customers can use the networkHeadersCapture and networkBodyCapture flags to decide whether to capture header or body information. Additionally, we will issue a warning when customers are still using advancedNetworkCapture in the current version, informing them that the advancedNetworkCapture flag will be deprecated in the next version.

```
export type SDKConfig = {
  advancedNetworkCapture?: boolean;
  networkHeadersCapture?: boolean; // new flag
  networkBodyCapture?: boolean; // new flag
  betaMode?: boolean;
  consoleCapture?: boolean;
  instrumentations?: InstrumentationConfigMap;
  additionalInstrumentations?: InstrumentationBase[];
  stopOnTerminationSignals?: boolean;
};
```
