### PR TITLE
fix: nested winston import

### DIFF
--- a/.changeset/clever-crews-matter.md
+++ b/.changeset/clever-crews-matter.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/node-opentelemetry': patch
+---
+
+fix: nested winston import

--- a/packages/node-opentelemetry/examples/dashr.js
+++ b/packages/node-opentelemetry/examples/dashr.js
@@ -1,0 +1,3 @@
+const { initSDK } = require('../build/src/index');
+
+initSDK({ consoleCapture: true });

--- a/packages/node-opentelemetry/examples/dummy.js
+++ b/packages/node-opentelemetry/examples/dummy.js
@@ -18,7 +18,7 @@ const { setTraceAttributes } = require('../build/src');
 //   process.exit(0);
 // });
 
-const PORT = parseInt(process.env.PORT || '7777');
+const PORT = parseInt(process.env.PORT || '7788');
 const app = express();
 
 const logger = winston.createLogger({
@@ -99,7 +99,6 @@ app.post('/dump', (req, res) => {
 });
 
 app.get('/', async (req, res) => {
-  console.info('@@@@@@@@@@@@');
   console.debug({
     headers: req.headers,
     method: req.method,
@@ -107,13 +106,14 @@ app.get('/', async (req, res) => {
     query: req.query,
   });
   console.error('BANG !!!');
+  console.log('Console 🍕');
   logger.info({
-    message: '🍕',
+    message: 'Winston 🍕',
     headers: req.headers,
     method: req.method,
     url: req.url,
   });
-  pinoLogger.info('🍕');
+  pinoLogger.info('Pino 🍕');
 
   console.log(await sendGetRequest());
   // console.log(await axios.get('https://hyperdx.free.beeceptor.com'));

--- a/packages/node-opentelemetry/src/logger.ts
+++ b/packages/node-opentelemetry/src/logger.ts
@@ -1,7 +1,6 @@
 import opentelemetry from '@opentelemetry/api';
 
-// @ts-ignore
-import { HyperDXWinston } from '@hyperdx/node-logger';
+import HyperDXWinston from '@hyperdx/node-logger/build/src/winston';
 
 import hdx from './debug';
 import { hyperDXGlobalContext } from './context';


### PR DESCRIPTION
The imports 'winston' in nest logger (https://github.com/hyperdxio/hyperdx-js/blob/fd71f420890b6736a34d6c7531afa0dc4be55f81/packages/node-logger/src/nest.ts#L1) that conflicts with the custom auto instrumentation pkg since winston will get initialized before otel winston's patch.

To avoid the issue, we don't want to import the node-logger index file