### PR TITLE
fix: declare `@opentelemetry/api` as a peer dep

### DIFF
--- a/.changeset/smart-trainers-study.md
+++ b/.changeset/smart-trainers-study.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/node-opentelemetry': patch
+---
+
+fix: declare @opentelemetry/api as a peer dependency

--- a/packages/node-opentelemetry/package.json
+++ b/packages/node-opentelemetry/package.json
@@ -32,7 +32,7 @@
     "prettier": "prettier --config .prettierrc --write ."
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.9.0"
+    "@opentelemetry/api": "1.x"
   },
   "dependencies": {
     "@opentelemetry/api-logs": "^0.51.0",

--- a/packages/node-opentelemetry/package.json
+++ b/packages/node-opentelemetry/package.json
@@ -31,8 +31,10 @@
     "ci:unit": "jest --coverage --ci",
     "prettier": "prettier --config .prettierrc --write ."
   },
+  "peerDependencies": {
+    "@opentelemetry/api": ">=1.3.0 <1.9.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/api-logs": "^0.51.0",
     "@opentelemetry/auto-instrumentations-node": "^0.46.0",
     "@opentelemetry/core": "^1.24.0",
@@ -59,6 +61,7 @@
   },
   "devDependencies": {
     "@koa/router": "^12.0.0",
+    "@opentelemetry/api": "^1.8.0",
     "compression": "^1.7.4",
     "express": "^4.19.2",
     "koa": "^2.14.2",


### PR DESCRIPTION
`@opentelemetry/api` should be a peer dependency since users might import their own version of api and create custom traces