### PR TITLE
fix: introduce pino mixin function to handle trace/span id injection issue

### DIFF
--- a/.changeset/silly-ravens-invent.md
+++ b/.changeset/silly-ravens-invent.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/node-opentelemetry': patch
+---
+
+fix: introduce pino mixin function to handle trace/span id injection issue

--- a/packages/node-opentelemetry/README.md
+++ b/packages/node-opentelemetry/README.md
@@ -25,7 +25,7 @@ configure your logging module.
 
 ```ts
 import winston from 'winston';
-import { getWinstonTransport } from '@hyperdx/node-opentelemetry';
+import * as HyperDX from '@hyperdx/node-opentelemetry';
 
 const MAX_LEVEL = 'info';
 
@@ -34,7 +34,7 @@ const logger = winston.createLogger({
   format: winston.format.json(),
   transports: [
     new winston.transports.Console(),
-    getWinstonTransport(MAX_LEVEL), // append this to the existing transports
+    HyperDX.getWinstonTransport(MAX_LEVEL), // append this to the existing transports
   ],
 });
 
@@ -45,18 +45,21 @@ export default logger;
 
 ```ts
 import pino from 'pino';
-import { getPinoTransport } from '@hyperdx/node-opentelemetry';
+import * as HyperDX from '@hyperdx/node-opentelemetry';
 
 const MAX_LEVEL = 'info';
 
-const logger = pino(
-  pino.transport({
+const logger = pino({
+  mixin: HyperDX.getPinoMixinFunction,
+  transport: {
     targets: [
-      getPinoTransport(MAX_LEVEL),
+      HyperDX.getPinoTransport(MAX_LEVEL),
       // other transports
     ],
-  }),
-);
+  },
+});
+
+export default logger;
 ```
 
 ### Configure Environment Variables

--- a/packages/node-opentelemetry/examples/dummy.js
+++ b/packages/node-opentelemetry/examples/dummy.js
@@ -25,13 +25,13 @@ const mongoose = require('mongoose');
 const mysql = require('mysql');
 const mysql2 = require('mysql2');
 const pg = require('pg');
-const pino = require('pino');
 const winston = require('winston');
+const pino = require('pino');
 
 const HyperDX = require('../build/src');
 
 HyperDX.init({
-  apiKey: 'blabla',
+  apiKey: '',
 });
 
 // setTimeout(() => {
@@ -80,14 +80,15 @@ const logger = winston.createLogger({
   ],
 });
 
-const pinoLogger = pino(
-  pino.transport({
+const pinoLogger = pino({
+  mixin: HyperDX.getPinoMixinFunction,
+  transport: {
     targets: [
       HyperDX.getPinoTransport('info'),
       // other transports
     ],
-  }),
-);
+  },
+});
 
 const bunyanLogger = bunyan.createLogger({ name: 'myapp' });
 

--- a/packages/node-opentelemetry/src/logger.ts
+++ b/packages/node-opentelemetry/src/logger.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_HDX_NODE_BETA_MODE,
   DEFAULT_SERVICE_NAME,
 } from './constants';
+import * as HyperDXPino from './otel-logger/pino';
 import HyperDXWinston from './otel-logger/winston';
 
 import type { HyperDXPinoOptions } from './otel-logger/pino';
@@ -55,11 +56,13 @@ export const getWinstonTransport = (
 // TODO: WILL BE DEPRECATED
 export const getWinsonTransport = getWinstonTransport;
 
+export const getPinoMixinFunction = HyperDXPino.getMixinFunction;
 export const getPinoTransport = (
   maxLevel = 'info',
   options: PinotTransportOptions = {},
 ) => {
   const apiKey = DEFAULT_HDX_API_KEY();
+
   return {
     target: '@hyperdx/node-opentelemetry/build/src/otel-logger/pino',
     options: {

--- a/packages/node-opentelemetry/src/otel-logger/pino.ts
+++ b/packages/node-opentelemetry/src/otel-logger/pino.ts
@@ -71,11 +71,10 @@ export const getMixinFunction = () => {
   if (!isSpanContextValid(spanContext)) {
     return {};
   }
-  const logKeys = DEFAULT_LOG_KEYS;
   return {
-    [logKeys.traceId]: spanContext.traceId,
-    [logKeys.spanId]: spanContext.spanId,
-    [logKeys.traceFlags]: `0${spanContext.traceFlags.toString(16)}`,
+    [DEFAULT_LOG_KEYS.traceId]: spanContext.traceId,
+    [DEFAULT_LOG_KEYS.spanId]: spanContext.spanId,
+    [DEFAULT_LOG_KEYS.traceFlags]: `0${spanContext.traceFlags.toString(16)}`,
   };
 };
 

--- a/packages/node-opentelemetry/src/otel-logger/pino.ts
+++ b/packages/node-opentelemetry/src/otel-logger/pino.ts
@@ -1,6 +1,12 @@
 import build from 'pino-abstract-transport';
 import isString from 'lodash.isstring';
-import { Attributes, diag } from '@opentelemetry/api';
+import {
+  Attributes,
+  context,
+  diag,
+  isSpanContextValid,
+  trace,
+} from '@opentelemetry/api';
 
 import { Logger } from './';
 import { jsonToString } from '../utils';
@@ -46,6 +52,31 @@ const PINO_LEVELS = {
 export type HyperDXPinoOptions = LoggerOptions & {
   apiKey?: string;
   getCustomMeta?: () => Attributes;
+};
+
+// https://github.com/open-telemetry/opentelemetry-js-contrib/blob/65bc979f9f04410e9a78b4d546f5e08471c1fb6d/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts#L167C11-L167C30
+const DEFAULT_LOG_KEYS = {
+  traceId: 'trace_id',
+  spanId: 'span_id',
+  traceFlags: 'trace_flags',
+};
+export const getMixinFunction = () => {
+  const span = trace.getSpan(context.active());
+  if (!span) {
+    return {};
+  }
+
+  const spanContext = span.spanContext();
+
+  if (!isSpanContextValid(spanContext)) {
+    return {};
+  }
+  const logKeys = DEFAULT_LOG_KEYS;
+  return {
+    [logKeys.traceId]: spanContext.traceId,
+    [logKeys.spanId]: spanContext.spanId,
+    [logKeys.traceFlags]: `0${spanContext.traceFlags.toString(16)}`,
+  };
 };
 
 export default async ({


### PR DESCRIPTION
## Issue
The pino instrumentation won't work (https://www.npmjs.com/package/@opentelemetry/instrumentation-pino) with programmatic import. it seems tricky to attach span/trace id on the transport layer due to the async stream implementation.

## Solution
Giving user the custom mixin function which attaches span/trace id