### PR TITLE
Update package.json

### DIFF
--- a/packages/node-opentelemetry/package.json
+++ b/packages/node-opentelemetry/package.json
@@ -55,6 +55,7 @@
     "lodash.isobject": "^3.0.2",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
+    "node-fetch": "^2.7.0",
     "open": "^8.4.2",
     "ora": "^5.4.1",
     "pino-abstract-transport": "^1.2.0",


### PR DESCRIPTION
```
ailed to prepare server Error [ERR_REQUIRE_ESM]: require() of ES Module /var/task/node_modules/.pnpm/node-fetch@3.3.2/node_modules/node-fetch/src/index.js from /var/task/node_modules/.pnpm/@hyperdx+node-opentelemetry@0.8.0_encoding@0.1.13/node_modules/@hyperdx/node-opentelemetry/build/src/otel.js not supported.
Instead change the require of index.js in /var/task/node_modules/.pnpm/@hyperdx+node-opentelemetry@0.8.0_encoding@0.1.13/node_modules/@hyperdx/node-opentelemetry/build/src/otel.js to a dynamic import() which is available in all CommonJS modules.
    at /opt/rust/nodejs.js:1:11506
    at Function.Xt (/opt/rust/nodejs.js:1:11878)
    at Z.e.<computed>.X._load (/opt/rust/nodejs.js:1:11476)
    at u.require (/var/task/node_modules/.pnpm/next@14.2.5_@babel+core@7.24.8_@opentelemetry+api@1.9.0_@playwright+test@1.45.1_babel-plugin-_avtw3s2n4yvxy3ilqu7pouqafq/node_modules/next/dist/compiled/next-server/server.runtime.prod.js:11:29195)
    at Object.<anonymous> (/var/task/node_modules/.pnpm/@hyperdx+node-opentelemetry@0.8.0_encoding@0.1.13/node_modules/@hyperdx/node-opentelemetry/build/src/otel.js:5:46) {
  code: 'ERR_REQUIRE_ESM'
}
```