### PR TITLE
Feature Improvement: Add url option to open-telemetry SDK config

### DIFF
--- a/packages/node-opentelemetry/src/metrics.ts
+++ b/packages/node-opentelemetry/src/metrics.ts
@@ -5,21 +5,16 @@ import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import {
   DEFAULT_OTEL_METRIC_EXPORT_INTERVAL,
   DEFAULT_OTEL_METRIC_EXPORT_TIMEOUT,
-  DEFAULT_OTEL_METRICS_EXPORTER_URL,
 } from './constants';
 
 const env = process.env;
 
-export const getHyperDXMetricReader = () =>
+export const getHyperDXMetricReader = (url: string) =>
   new PeriodicExportingMetricReader({
     exporter:
       env.OTEL_EXPORTER_OTLP_PROTOCOL === 'grpc'
-        ? new OTLPMetricExporterGRPC({
-            url: DEFAULT_OTEL_METRICS_EXPORTER_URL,
-          })
-        : new OTLPMetricExporterHTTP({
-            url: DEFAULT_OTEL_METRICS_EXPORTER_URL,
-          }),
+        ? new OTLPMetricExporterGRPC({ url })
+        : new OTLPMetricExporterHTTP({ url }),
     exportIntervalMillis: DEFAULT_OTEL_METRIC_EXPORT_INTERVAL,
     exportTimeoutMillis: DEFAULT_OTEL_METRIC_EXPORT_TIMEOUT,
   });


### PR DESCRIPTION
Currently, the HyperDX Node SDK reads the OTLP endpoint exclusively from environment variables (OTEL_EXPORTER_OTLP_ENDPOINT). This works well for simple setups, but becomes problematic when running multiple OTEL collectors in the same environment.

In my team's case, we use multiple OTEL collectors and need to send telemetry from HyperDX to a different endpoint than our other instrumentation. Since OTEL_EXPORTER_OTLP_ENDPOINT is already in use, and the SDK defaults to https://in-otel.hyperdx.io when not set, there's no way to programmatically override the endpoint.
Solution

So, I've added an optional endpoint config option to init() / initSDK():

```
HyperDX.init({service: 'my-app', apiKey: process.env.HYPERDX_API_KEY, url: 'http://my-otel-collector:4318',});
```

Gives users explicit control over where telemetry is sent.