### PR TITLE
Support per-signal OTLP exporter endpoints in hyperdx/browser

### DIFF
--- a/.changeset/fifty-states-beam.md
+++ b/.changeset/fifty-states-beam.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/browser': patch
+---
+
+Support per-signal OTLP exporter endpoints in hyperdx/browser

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -33,6 +33,8 @@ type BrowserSDKConfig = {
   service: string;
   tracePropagationTargets?: (string | RegExp)[];
   url?: string;
+  tracesUrl?: string;
+  logsUrl?: string;
   otelResourceAttributes?: ResourceAttributes;
 };
 
@@ -66,6 +68,8 @@ class Browser {
     service,
     tracePropagationTargets,
     url,
+    tracesUrl,
+    logsUrl,
     otelResourceAttributes,
   }: BrowserSDKConfig) {
     if (!hasWindow()) {
@@ -85,12 +89,14 @@ class Browser {
     }
 
     const urlBase = url ?? URL_BASE;
+    const resolvedTracesUrl = tracesUrl ?? `${urlBase}/v1/traces`;
+    const resolvedLogsUrl = logsUrl ?? `${urlBase}/v1/logs`;
 
     this._advancedNetworkCapture = advancedNetworkCapture;
 
     Rum.init({
       debug,
-      url: `${urlBase}/v1/traces`,
+      url: resolvedTracesUrl,
       allowInsecureUrl: true,
       apiKey,
       applicationName: service,
@@ -130,7 +136,7 @@ class Browser {
         maskTextSelector: maskAllText ? '*' : undefined,
         recordCanvas,
         sampling,
-        url: `${urlBase}/v1/logs`,
+        url: resolvedLogsUrl,
       });
     }
 


### PR DESCRIPTION
## Summary

Add optional `tracesUrl` and `logsUrl` config options to `@hyperdx/browser`'s `init()`,
allowing independent configuration of trace and log export endpoints.

This is useful for complex networking environments or when routing different
telemetry signals to different backends (e.g. traces to one collector, session
replay logs to another).

## Changes

- Added optional `tracesUrl` and `logsUrl` fields to `BrowserSDKConfig`
- When provided, these are used as-is for the Rum (traces) and SessionRecorder (logs)
  OTLP exporters respectively
- When omitted, the existing behavior is preserved: `${url}/v1/traces` and `${url}/v1/logs`

## Usage

```ts
HyperDX.init({
  apiKey: '...',
  service: 'my-app',
  url: 'https://collector.example.com',                // base URL (existing behavior)
  tracesUrl: 'https://traces.example.com/v1/traces',   // optional override
  logsUrl: 'https://logs.example.com/v1/logs',         // optional override
});
```

## Context
- Related issue: hyperdxio/hyperdx#2076
- Related PR: hyperdxio/hyperdx#2098