### PR TITLE
fix: don't lint otel-web package

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  '**/*.{ts,tsx}': (files) => {
+    const cmds = [`prettier --write --ignore-unknown ${files.join(' ')}`];
+
+    // `otel-web` package does not have an eslint config yet
+    const lintable = files.filter((f) => !f.includes('/packages/otel-web/'));
+
+    if (lintable.length) {
+      cmds.push(`eslint --fix ${lintable.join(' ')}`);
+    }
+
+    return cmds;
+  },
+
+  '**/*.{json,yml}': 'prettier --write --ignore-unknown',
+};

--- a/package.json
+++ b/package.json
@@ -18,15 +18,6 @@
     "release:next": "npx nx run-many --target=build && yarn changeset version --snapshot next && npx nx run-many --target=postversion && yarn changeset publish --tag next",
     "prepare": "husky install"
   },
-  "lint-staged": {
-    "**/*.{ts,tsx}": [
-      "prettier --write --ignore-unknown",
-      "eslint --fix"
-    ],
-    "**/*.{json,yml}": [
-      "prettier --write --ignore-unknown"
-    ]
-  },
   "devDependencies": {
     "@changesets/cli": "^2.26.1",
     "@types/debug": "^4.1.8",


### PR DESCRIPTION
Release jobs are currently failing because there is no eslint config in the otel-web package when lint-staged runs. E.g: https://github.com/hyperdxio/hyperdx-js/actions/runs/24661143137/job/72107168254

This PR filters out files from `otel-web` for eslint to run against via lint-staged.