### PR TITLE
fix(instrumentation-exception): use JSON.stringify for object args in console.error

### DIFF
--- a/.changeset/good-icons-rule.md
+++ b/.changeset/good-icons-rule.md
@@ -1,0 +1,5 @@
+---
+'@hyperdx/instrumentation-exception': minor
+---
+
+Improve how instrumation-exception stringifies properties like arrays and objects

--- a/packages/instrumentation-exception/src/browser/instrumentations/HyperDXErrorInstrumentation.ts
+++ b/packages/instrumentation-exception/src/browser/instrumentations/HyperDXErrorInstrumentation.ts
@@ -6,7 +6,7 @@ import {
 import * as shimmer from 'shimmer';
 
 import { recordException } from '../';
-import { getElementXPath, limitLen } from './utils';
+import { getElementXPath, limitLen, stringifyValue } from './utils';
 
 // FIXME take timestamps from events?
 
@@ -15,14 +15,6 @@ const MESSAGE_LIMIT = 1024;
 
 function useful(s) {
   return s && s.trim() !== '' && !s.startsWith('[object') && s !== 'error';
-}
-
-function stringifyValue(value: unknown) {
-  if (value === undefined) {
-    return '(undefined)';
-  }
-
-  return value.toString();
 }
 
 function addStackIfUseful(span: Span, err: Error) {
@@ -210,7 +202,7 @@ export class HyperDXErrorInstrumentation extends InstrumentationBase {
         firstError,
       );
     } else {
-      this.hdxReportString(source, stringifyValue(arg)); // FIXME or JSON.stringify?
+      this.hdxReportString(source, stringifyValue(arg));
     }
   }
 }

--- a/packages/instrumentation-exception/src/browser/instrumentations/__tests__/HyperDXErrorInstrumentation.test.ts
+++ b/packages/instrumentation-exception/src/browser/instrumentations/__tests__/HyperDXErrorInstrumentation.test.ts
@@ -1,0 +1,96 @@
+import { stringifyValue } from '../utils';
+
+describe('stringifyValue', () => {
+  it('should JSON.stringify plain objects instead of producing [object Object]', () => {
+    const obj = { errorId: 'abc-123', details: 'something broke' };
+    const result = stringifyValue(obj);
+
+    expect(result).not.toContain('[object Object]');
+    expect(result).toContain('errorId');
+    expect(result).toContain('abc-123');
+    expect(result).toBe('{"errorId":"abc-123","details":"something broke"}');
+  });
+
+  it('should handle nested objects', () => {
+    const result = stringifyValue({ outer: { inner: 'value' } });
+
+    expect(result).not.toContain('[object Object]');
+    expect(result).toContain('inner');
+    expect(result).toBe('{"outer":{"inner":"value"}}');
+  });
+
+  it('should handle null', () => {
+    expect(stringifyValue(null)).toBe('null');
+  });
+
+  it('should handle undefined', () => {
+    expect(stringifyValue(undefined)).toBe('(undefined)');
+  });
+
+  it('should use error.message for Error objects instead of JSON.stringify', () => {
+    const err = new Error('something failed');
+    const result = stringifyValue(err);
+
+    // JSON.stringify(err) would produce "{}" because Error properties are non-enumerable
+    expect(result).not.toBe('{}');
+    expect(result).toContain('something failed');
+  });
+
+  it('should handle Error objects with no message', () => {
+    const err = new Error();
+    const result = stringifyValue(err);
+
+    // Should fall back to toString() which gives "Error"
+    expect(result).toBeTruthy();
+  });
+
+  it('should handle arrays', () => {
+    const result = stringifyValue([1, 2, 3]);
+
+    expect(result).not.toContain('[object Object]');
+    expect(result).toBe('[1,2,3]');
+  });
+
+  it('should handle strings as-is', () => {
+    expect(stringifyValue('hello')).toBe('hello');
+  });
+
+  it('should handle numbers', () => {
+    expect(stringifyValue(42)).toBe('42');
+  });
+
+  it('should handle booleans', () => {
+    expect(stringifyValue(true)).toBe('true');
+    expect(stringifyValue(false)).toBe('false');
+  });
+
+  it('should handle objects with circular references gracefully', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const obj: any = { a: 1 };
+    obj.self = obj;
+
+    // Should not throw, falls back to toString()
+    const result = stringifyValue(obj);
+    expect(result).toBeDefined();
+  });
+
+  it('should produce correct output for the reported console.error scenario', () => {
+    // Simulates: console.error('FatalErrorBoundary caught an error', { errorId, error, errorInfo })
+    // The hdxReport method joins stringifyValue results with spaces
+    const args = [
+      'FatalErrorBoundary caught an error',
+      {
+        errorId: 'err-001',
+        error: 'TypeError: Cannot read properties of null',
+        errorInfo: { componentStack: 'at App' },
+      },
+    ];
+
+    const message = args.map((x) => stringifyValue(x)).join(' ');
+
+    expect(message).not.toContain('[object Object]');
+    expect(message).toContain('FatalErrorBoundary caught an error');
+    expect(message).toContain('errorId');
+    expect(message).toContain('err-001');
+  });
+});

--- a/packages/instrumentation-exception/src/browser/instrumentations/__tests__/HyperDXErrorInstrumentation.test.ts
+++ b/packages/instrumentation-exception/src/browser/instrumentations/__tests__/HyperDXErrorInstrumentation.test.ts
@@ -44,7 +44,15 @@ describe('stringifyValue', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should handle arrays', () => {
+  it('should return empty string for empty objects', () => {
+    expect(stringifyValue({})).toBe('');
+  });
+
+  it('should return empty string for empty arrays', () => {
+    expect(stringifyValue([])).toBe('');
+  });
+
+  it('should handle non-empty arrays', () => {
     const result = stringifyValue([1, 2, 3]);
 
     expect(result).not.toContain('[object Object]');

--- a/packages/instrumentation-exception/src/browser/instrumentations/utils.ts
+++ b/packages/instrumentation-exception/src/browser/instrumentations/utils.ts
@@ -1,3 +1,27 @@
+export function stringifyValue(value: unknown): string {
+  if (value === undefined) {
+    return '(undefined)';
+  }
+
+  if (value === null) {
+    return 'null';
+  }
+
+  if (value instanceof Error) {
+    return value.message || value.toString();
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch (e) {
+      return value.toString();
+    }
+  }
+
+  return value.toString();
+}
+
 export function limitLen(s: string, cap: number): string {
   if (s.length > cap) {
     return s.substring(0, cap);

--- a/packages/instrumentation-exception/src/browser/instrumentations/utils.ts
+++ b/packages/instrumentation-exception/src/browser/instrumentations/utils.ts
@@ -13,7 +13,12 @@ export function stringifyValue(value: unknown): string {
 
   if (typeof value === 'object') {
     try {
-      return JSON.stringify(value);
+      const result = JSON.stringify(value);
+      // Empty objects/arrays carry no useful error info
+      if (result === '{}' || result === '[]') {
+        return '';
+      }
+      return result;
     } catch (e) {
       return value.toString();
     }


### PR DESCRIPTION
## Summary

- Fix `stringifyValue` to use `JSON.stringify` for objects instead of `.toString()`, which was producing `[object Object]` in `error.message` span attributes
- Add proper handling for `null` (was crashing), `Error` instances (use `.message` since `JSON.stringify(err)` returns `"{}"`), and circular references (graceful fallback)
- Add 12 unit tests covering all value types and the exact reported scenario

## Problem

When calling:
```js
console.error('FatalErrorBoundary caught an error', {
  errorId: this.state.errorId,
  error,
  errorInfo,
});
```

The `error.message` span attribute was reported as:
```
FatalErrorBoundary caught an error [object Object]
```

Because `stringifyValue` used `.toString()` on all values, which returns `[object Object]` for plain objects.

## Fix

Moved `stringifyValue` to `utils.ts` as an exported function with proper type-specific serialization:
- **Objects** → `JSON.stringify(value)` with `try/catch` fallback for circular refs
- **Errors** → `error.message` (since `JSON.stringify(new Error())` produces `"{}"`)
- **null** → `"null"` (previously crashed with `TypeError`)
- **Primitives** → `.toString()` (unchanged)

Resolves HDX-4154