### PR TITLE
fix(otel-web): reduce flakiness in unloaded img test

### DIFF
--- a/packages/otel-web/test/init.test.ts
+++ b/packages/otel-web/test/init.test.ts
@@ -399,23 +399,34 @@ describe('test error', () => {
     setTimeout(() => {
       callChain();
     }, 10);
-    // and later look for it
-    setTimeout(() => {
+    // Poll for the specific onerror span instead of grabbing the last span,
+    // which may be a leaked span from a prior test's async recordException.
+    const pollInterval = 50;
+    const maxWait = 5000;
+    let elapsed = 0;
+    const check = () => {
       window.onerror = origOnError; // restore proper error handling
-      const span = capturer.spans[capturer.spans.length - 1];
-      assert.strictEqual(span.attributes.component, 'error');
-      assert.strictEqual(span.name, 'onerror');
-      assert.ok(
-        (span.attributes['error.stack'] as string).includes('callChain'),
-      );
-      assert.ok(
-        (span.attributes['error.stack'] as string).includes('reportError'),
-      );
-      assert.ok(
-        (span.attributes['error.message'] as string).includes('war room'),
-      );
-      done();
-    }, 100);
+      const span = capturer.spans.find((s) => s.name === 'onerror');
+      if (span) {
+        assert.strictEqual(span.attributes.component, 'error');
+        assert.ok(
+          (span.attributes['error.stack'] as string).includes('callChain'),
+        );
+        assert.ok(
+          (span.attributes['error.stack'] as string).includes('reportError'),
+        );
+        assert.ok(
+          (span.attributes['error.message'] as string).includes('war room'),
+        );
+        done();
+      } else if (elapsed >= maxWait) {
+        done(new Error('Timed out waiting for onerror span'));
+      } else {
+        elapsed += pollInterval;
+        setTimeout(check, pollInterval);
+      }
+    };
+    setTimeout(check, pollInterval);
   });
 });
 
@@ -445,25 +456,38 @@ describe('test stack length', () => {
         // swallow
       }
     }
-    setTimeout(() => {
+    const pollInterval = 50;
+    const maxWait = 5000;
+    let elapsed = 0;
+    const check = () => {
       const errorSpan = capturer.spans.find(
-        (span) => span.attributes.component === 'error',
+        (span) =>
+          span.attributes.component === 'error' &&
+          (span.attributes['error.message'] as string)?.includes('bad thing'),
       );
-      assert.ok(errorSpan);
-      assert.ok(
-        (errorSpan.attributes['error.stack'] as string).includes(
-          'recurAndThrow',
-        ),
-      );
-      assert.ok((errorSpan.attributes['error.stack'] as string).length <= 4096);
-      assert.ok(
-        (errorSpan.attributes['error.message'] as string).includes('something'),
-      );
-      assert.ok(
-        (errorSpan.attributes['error.message'] as string).includes('bad thing'),
-      );
-      done();
-    }, 100);
+      if (errorSpan) {
+        assert.ok(
+          (errorSpan.attributes['error.stack'] as string).includes(
+            'recurAndThrow',
+          ),
+        );
+        assert.ok(
+          (errorSpan.attributes['error.stack'] as string).length <= 4096,
+        );
+        assert.ok(
+          (errorSpan.attributes['error.message'] as string).includes(
+            'something',
+          ),
+        );
+        done();
+      } else if (elapsed >= maxWait) {
+        done(new Error('Timed out waiting for error span with recurAndThrow'));
+      } else {
+        elapsed += pollInterval;
+        setTimeout(check, pollInterval);
+      }
+    };
+    setTimeout(check, pollInterval);
   });
 });
 
@@ -483,20 +507,33 @@ describe('test unhandled promise rejection', () => {
     Promise.resolve('ok').then(() => {
       throwBacon();
     });
-    setTimeout(() => {
+    const pollInterval = 50;
+    const maxWait = 5000;
+    let elapsed = 0;
+    const check = () => {
       const errorSpan = capturer.spans.find(
-        (span) => span.attributes.component === 'error',
+        (span) =>
+          span.name === 'unhandledrejection' &&
+          (span.attributes['error.message'] as string)?.includes('bacon'),
       );
-      assert.ok(errorSpan);
-      assert.ok(errorSpan.attributes.error);
-      assert.ok(
-        (errorSpan.attributes['error.stack'] as string).includes('throwBacon'),
-      );
-      assert.ok(
-        (errorSpan.attributes['error.message'] as string).includes('bacon'),
-      );
-      done();
-    }, 100);
+      if (errorSpan) {
+        assert.ok(errorSpan.attributes.error);
+        assert.ok(
+          (errorSpan.attributes['error.stack'] as string).includes(
+            'throwBacon',
+          ),
+        );
+        done();
+      } else if (elapsed >= maxWait) {
+        done(
+          new Error('Timed out waiting for unhandledrejection span (bacon)'),
+        );
+      } else {
+        elapsed += pollInterval;
+        setTimeout(check, pollInterval);
+      }
+    };
+    setTimeout(check, pollInterval);
   });
 });
 
@@ -511,17 +548,27 @@ describe('test console.error', () => {
 
   it('should report a span', (done) => {
     console.error('has', 'some', 'args');
-    setTimeout(() => {
+    const pollInterval = 50;
+    const maxWait = 5000;
+    let elapsed = 0;
+    const check = () => {
       const errorSpan = capturer.spans.find(
-        (span) => span.attributes.component === 'error',
+        (span) => span.name === 'console.error',
       );
-      assert.ok(errorSpan);
-      assert.strictEqual(
-        errorSpan.attributes['error.message'],
-        'has some args',
-      );
-      done();
-    }, 100);
+      if (errorSpan) {
+        assert.strictEqual(
+          errorSpan.attributes['error.message'],
+          'has some args',
+        );
+        done();
+      } else if (elapsed >= maxWait) {
+        done(new Error('Timed out waiting for console.error span'));
+      } else {
+        elapsed += pollInterval;
+        setTimeout(check, pollInterval);
+      }
+    };
+    setTimeout(check, pollInterval);
   });
 });
 
@@ -546,14 +593,12 @@ describe('test unloaded img', () => {
     // Poll for the span instead of using a fixed timeout, since the error
     // event and the async recordException chain may resolve at varying speeds.
     const pollInterval = 50;
-    const maxWait = 1000;
+    const maxWait = 5000;
     let elapsed = 0;
     const check = () => {
-      const span = capturer.spans.find(
-        (s) => s.attributes.component === 'error',
-      );
+      const span = capturer.spans.find((s) => s.name === 'eventListener.error');
       if (span) {
-        assert.strictEqual(span.name, 'eventListener.error');
+        assert.strictEqual(span.attributes.component, 'error');
         assert.ok(
           (span.attributes.target_src as string).endsWith('DoesNotExist.jpg'),
         );

--- a/packages/otel-web/test/init.test.ts
+++ b/packages/otel-web/test/init.test.ts
@@ -542,18 +542,30 @@ describe('test unloaded img', () => {
       location.href +
       '/IAlwaysWantToUseVeryVerboseDescriptionsWhenIHaveToEnsureSomethingDoesNotExist.jpg';
     document.body.appendChild(img);
-    setTimeout(() => {
+
+    // Poll for the span instead of using a fixed timeout, since the error
+    // event and the async recordException chain may resolve at varying speeds.
+    const pollInterval = 50;
+    const maxWait = 1000;
+    let elapsed = 0;
+    const check = () => {
       const span = capturer.spans.find(
         (s) => s.attributes.component === 'error',
       );
-      assert.ok(span);
-      assert.strictEqual(span.name, 'eventListener.error');
-      assert.ok(
-        (span.attributes.target_src as string).endsWith('DoesNotExist.jpg'),
-      );
-
-      done();
-    }, 100);
+      if (span) {
+        assert.strictEqual(span.name, 'eventListener.error');
+        assert.ok(
+          (span.attributes.target_src as string).endsWith('DoesNotExist.jpg'),
+        );
+        done();
+      } else if (elapsed >= maxWait) {
+        done(new Error('Timed out waiting for error span from unloaded img'));
+      } else {
+        elapsed += pollInterval;
+        setTimeout(check, pollInterval);
+      }
+    };
+    setTimeout(check, pollInterval);
   });
 });
 

--- a/packages/otel-web/test/init.test.ts
+++ b/packages/otel-web/test/init.test.ts
@@ -18,7 +18,12 @@ import * as assert from 'assert';
 import Rum from '../src/index';
 import { context, diag, trace } from '@opentelemetry/api';
 import * as tracing from '@opentelemetry/sdk-trace-base';
-import { deinit, initWithDefaultConfig, SpanCapturer } from './utils';
+import {
+  deinit,
+  initWithDefaultConfig,
+  SpanCapturer,
+  waitForSpan,
+} from './utils';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -395,19 +400,17 @@ describe('test error', () => {
       // nop to prevent failing the test
     };
     capturer.clear();
-    // cause the error
     setTimeout(() => {
       callChain();
     }, 10);
-    // Poll for the specific onerror span instead of grabbing the last span,
-    // which may be a leaked span from a prior test's async recordException.
-    const pollInterval = 50;
-    const maxWait = 5000;
-    let elapsed = 0;
-    const check = () => {
-      window.onerror = origOnError; // restore proper error handling
-      const span = capturer.spans.find((s) => s.name === 'onerror');
-      if (span) {
+    waitForSpan(
+      capturer,
+      (s) => s.name === 'onerror',
+      (err) => {
+        window.onerror = origOnError;
+        done(err);
+      },
+      (span) => {
         assert.strictEqual(span.attributes.component, 'error');
         assert.ok(
           (span.attributes['error.stack'] as string).includes('callChain'),
@@ -418,15 +421,8 @@ describe('test error', () => {
         assert.ok(
           (span.attributes['error.message'] as string).includes('war room'),
         );
-        done();
-      } else if (elapsed >= maxWait) {
-        done(new Error('Timed out waiting for onerror span'));
-      } else {
-        elapsed += pollInterval;
-        setTimeout(check, pollInterval);
-      }
-    };
-    setTimeout(check, pollInterval);
+      },
+    );
   });
 });
 
@@ -456,38 +452,22 @@ describe('test stack length', () => {
         // swallow
       }
     }
-    const pollInterval = 50;
-    const maxWait = 5000;
-    let elapsed = 0;
-    const check = () => {
-      const errorSpan = capturer.spans.find(
-        (span) =>
-          span.attributes.component === 'error' &&
-          (span.attributes['error.message'] as string)?.includes('bad thing'),
-      );
-      if (errorSpan) {
+    waitForSpan(
+      capturer,
+      (s) =>
+        s.attributes.component === 'error' &&
+        (s.attributes['error.message'] as string)?.includes('bad thing'),
+      done,
+      (span) => {
         assert.ok(
-          (errorSpan.attributes['error.stack'] as string).includes(
-            'recurAndThrow',
-          ),
+          (span.attributes['error.stack'] as string).includes('recurAndThrow'),
         );
+        assert.ok((span.attributes['error.stack'] as string).length <= 4096);
         assert.ok(
-          (errorSpan.attributes['error.stack'] as string).length <= 4096,
+          (span.attributes['error.message'] as string).includes('something'),
         );
-        assert.ok(
-          (errorSpan.attributes['error.message'] as string).includes(
-            'something',
-          ),
-        );
-        done();
-      } else if (elapsed >= maxWait) {
-        done(new Error('Timed out waiting for error span with recurAndThrow'));
-      } else {
-        elapsed += pollInterval;
-        setTimeout(check, pollInterval);
-      }
-    };
-    setTimeout(check, pollInterval);
+      },
+    );
   });
 });
 
@@ -507,33 +487,19 @@ describe('test unhandled promise rejection', () => {
     Promise.resolve('ok').then(() => {
       throwBacon();
     });
-    const pollInterval = 50;
-    const maxWait = 5000;
-    let elapsed = 0;
-    const check = () => {
-      const errorSpan = capturer.spans.find(
-        (span) =>
-          span.name === 'unhandledrejection' &&
-          (span.attributes['error.message'] as string)?.includes('bacon'),
-      );
-      if (errorSpan) {
-        assert.ok(errorSpan.attributes.error);
+    waitForSpan(
+      capturer,
+      (s) =>
+        s.name === 'unhandledrejection' &&
+        (s.attributes['error.message'] as string)?.includes('bacon'),
+      done,
+      (span) => {
+        assert.ok(span.attributes.error);
         assert.ok(
-          (errorSpan.attributes['error.stack'] as string).includes(
-            'throwBacon',
-          ),
+          (span.attributes['error.stack'] as string).includes('throwBacon'),
         );
-        done();
-      } else if (elapsed >= maxWait) {
-        done(
-          new Error('Timed out waiting for unhandledrejection span (bacon)'),
-        );
-      } else {
-        elapsed += pollInterval;
-        setTimeout(check, pollInterval);
-      }
-    };
-    setTimeout(check, pollInterval);
+      },
+    );
   });
 });
 
@@ -548,27 +514,14 @@ describe('test console.error', () => {
 
   it('should report a span', (done) => {
     console.error('has', 'some', 'args');
-    const pollInterval = 50;
-    const maxWait = 5000;
-    let elapsed = 0;
-    const check = () => {
-      const errorSpan = capturer.spans.find(
-        (span) => span.name === 'console.error',
-      );
-      if (errorSpan) {
-        assert.strictEqual(
-          errorSpan.attributes['error.message'],
-          'has some args',
-        );
-        done();
-      } else if (elapsed >= maxWait) {
-        done(new Error('Timed out waiting for console.error span'));
-      } else {
-        elapsed += pollInterval;
-        setTimeout(check, pollInterval);
-      }
-    };
-    setTimeout(check, pollInterval);
+    waitForSpan(
+      capturer,
+      (s) => s.name === 'console.error',
+      done,
+      (span) => {
+        assert.strictEqual(span.attributes['error.message'], 'has some args');
+      },
+    );
   });
 });
 
@@ -590,27 +543,17 @@ describe('test unloaded img', () => {
       '/IAlwaysWantToUseVeryVerboseDescriptionsWhenIHaveToEnsureSomethingDoesNotExist.jpg';
     document.body.appendChild(img);
 
-    // Poll for the span instead of using a fixed timeout, since the error
-    // event and the async recordException chain may resolve at varying speeds.
-    const pollInterval = 50;
-    const maxWait = 5000;
-    let elapsed = 0;
-    const check = () => {
-      const span = capturer.spans.find((s) => s.name === 'eventListener.error');
-      if (span) {
+    waitForSpan(
+      capturer,
+      (s) => s.name === 'eventListener.error',
+      done,
+      (span) => {
         assert.strictEqual(span.attributes.component, 'error');
         assert.ok(
           (span.attributes.target_src as string).endsWith('DoesNotExist.jpg'),
         );
-        done();
-      } else if (elapsed >= maxWait) {
-        done(new Error('Timed out waiting for error span from unloaded img'));
-      } else {
-        elapsed += pollInterval;
-        setTimeout(check, pollInterval);
-      }
-    };
-    setTimeout(check, pollInterval);
+      },
+    );
   });
 });
 

--- a/packages/otel-web/test/utils.ts
+++ b/packages/otel-web/test/utils.ts
@@ -38,6 +38,39 @@ export class SpanCapturer implements SpanProcessor {
   }
 }
 
+/**
+ * Poll a SpanCapturer until a span matching `predicate` appears, then invoke
+ * `done`.  Uses polling instead of a fixed timeout so tests are resilient to
+ * async `recordException` completing at varying speeds (especially on CI).
+ */
+export function waitForSpan(
+  capturer: SpanCapturer,
+  predicate: (span: ReadableSpan) => boolean,
+  done: (err?: Error) => void,
+  assertions: (span: ReadableSpan) => void,
+  timeoutMsg = 'Timed out waiting for span',
+  { pollInterval = 50, maxWait = 5000 } = {},
+): void {
+  let elapsed = 0;
+  const check = (): void => {
+    const span = capturer.spans.find(predicate);
+    if (span) {
+      try {
+        assertions(span);
+        done();
+      } catch (e) {
+        done(e instanceof Error ? e : new Error(String(e)));
+      }
+    } else if (elapsed >= maxWait) {
+      done(new Error(timeoutMsg));
+    } else {
+      elapsed += pollInterval;
+      setTimeout(check, pollInterval);
+    }
+  };
+  setTimeout(check, pollInterval);
+}
+
 export function deinit(): void {
   Rum.deinit();
 }


### PR DESCRIPTION
## Summary
- Fix flaky error span tests (`test error`, `test unloaded img`, and others) that intermittently pick up leaked spans from prior tests
- Root cause: `recordException` is async, so spans from one test can resolve after `deinit()` and land in the next test's capturer
- Search for spans by name (`onerror`, `eventListener.error`, etc.) instead of the generic `component === 'error'` attribute
- Replace hardcoded `setTimeout` with polling via a shared `waitForSpan` helper in `test/utils.ts`

Example of flakiness:

<img width="1122" height="527" alt="Screenshot 2026-05-06 at 9 10 29 AM" src="https://github.com/user-attachments/assets/4c91aa60-5bad-4137-95c6-aa849ec3e006" />