### PR TITLE
fix(release): fix issue with release actions on session recorder

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,8 +2,12 @@ module.exports = {
   '**/*.{ts,tsx}': (files) => {
     const cmds = [`prettier --write --ignore-unknown ${files.join(' ')}`];
 
-    // `otel-web` package does not have an eslint config yet
-    const lintable = files.filter((f) => !f.includes('/packages/otel-web/'));
+    // These packages do not have an eslint config yet
+    const lintable = files.filter(
+      (f) =>
+        !f.includes('/packages/otel-web/') &&
+        !f.includes('/packages/session-recorder/'),
+    );
 
     if (lintable.length) {
       cmds.push(`eslint --fix ${lintable.join(' ')}`);


### PR DESCRIPTION
Release is currently failing because it attempts to run eslint on a package that does not have eslint configured. See https://github.com/hyperdxio/hyperdx-js/actions/runs/25444556479/job/74644906529