### PR TITLE
fix: moved phantom dep and upgraded

### DIFF
--- a/.changeset/remove-babel-runtime-phantom-dep.md
+++ b/.changeset/remove-babel-runtime-phantom-dep.md
@@ -1,0 +1,15 @@
+---
+"@hyperdx/otel-web-session-recorder": patch
+"@hyperdx/otel-web": patch
+"@hyperdx/browser": patch
+---
+
+Move `@babel/runtime` from runtime dependencies to devDependencies. The
+published CommonJS and ESM output (`dist/cjs/`, `dist/esm/`) is produced by
+`tsc` and does not reference `@babel/runtime` at all; only the unpublished
+Rollup IIFE bundle needed it. Keeping it as a runtime dependency forced
+consumers to install a vulnerable version of `@babel/runtime` (<7.26.10,
+GHSA-968p-4wvh-cqc8), surfacing as a moderate-severity finding in
+`npm audit`. With this change, a clean install of `@hyperdx/browser`,
+`@hyperdx/otel-web`, or `@hyperdx/otel-web-session-recorder` no longer
+pulls in the vulnerable `@babel/runtime` and `npm audit` is clean.

--- a/packages/otel-web/package.json
+++ b/packages/otel-web/package.json
@@ -48,7 +48,6 @@
     "dist/esm/*.d.ts"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.21.0",
     "@hyperdx/instrumentation-exception": "^0.2.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.7.1",
@@ -70,6 +69,7 @@
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.19.1",
     "@babel/preset-env": "^7.19.1",
+    "@babel/runtime": "^7.26.10",
     "@babel/runtime-corejs3": "^7.19.1",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^22.0.2",

--- a/packages/session-recorder/package.json
+++ b/packages/session-recorder/package.json
@@ -34,7 +34,6 @@
     "dist/esm/**/*.d.ts"
   ],
   "dependencies": {
-    "@babel/runtime": "~7.18.3",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.7.1",
     "@opentelemetry/resources": "^2.7.1",
@@ -50,6 +49,7 @@
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.19.1",
     "@babel/preset-env": "^7.19.1",
+    "@babel/runtime": "^7.26.10",
     "@babel/runtime-corejs3": "^7.19.1",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1666,12 +1666,17 @@
     core-js-pure "^3.30.2"
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.20.1", "@babel/runtime@^7.21.0", "@babel/runtime@^7.5.5":
+"@babel/runtime@^7.20.1", "@babel/runtime@^7.5.5":
   version "7.24.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.6.tgz#5b76eb89ad45e2e4a0a8db54c456251469a3358e"
   integrity sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==
   dependencies:
     regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.26.10":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
 
 "@babel/runtime@^7.8.4":
   version "7.24.7"
@@ -1679,13 +1684,6 @@
   integrity sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==
   dependencies:
     regenerator-runtime "^0.14.0"
-
-"@babel/runtime@~7.18.3":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
-  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
 
 "@babel/template@^7.24.6", "@babel/template@^7.3.3":
   version "7.24.6"
@@ -12777,11 +12775,6 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
-
-regenerator-runtime@^0.13.4:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
@babel/runtime was required as a dependency, but is not actually used except as a dev dependency. It made sense to move it.