### PR TITLE
feat(otel-web): add navigation context to webvitals, fix bfcache dedup

### DIFF
--- a/.changeset/webvitals-navigation-context.md
+++ b/.changeset/webvitals-navigation-context.md
@@ -1,0 +1,11 @@
+---
+"@hyperdx/otel-web": minor
+---
+
+webvitals spans now carry `webvitals.navigation_type` and `webvitals.metric_id`
+attributes, so downstream consumers can segment metrics by how the page was
+visited (`navigate`, `reload`, `back-forward`, `back-forward-cache`,
+`prerender`, `restore`) and correlate multiple values for the same metric
+instance. Metrics are also deduped by instance id (`metric.id`) instead of
+metric name, so measurements from back/forward-cache restores — which produce a
+new metric instance with a new id — are no longer dropped (#269).

--- a/packages/otel-web/src/webvitals.ts
+++ b/packages/otel-web/src/webvitals.ts
@@ -30,21 +30,27 @@ export function initWebVitals(
   callbacks: WebVitalsCallbacks = webVitalsLib,
 ): void {
   const tracer = provider.getTracer('webvitals');
-  // Per-init cache: each Core Web Vital callback may fire more than once
-  // in a page's lifetime (CLS in particular), and we only want to report
-  // each metric once. Scoped to this call so callers that re-init get a
-  // fresh cache instead of inheriting module-level state.
+  // Per-init cache keyed on the metric *instance* id (`metric.id`), not the
+  // metric name. A single Core Web Vital callback may fire more than once in
+  // a page's lifetime (CLS in particular), and we only want to report each
+  // instance once. Keying on name, however, would drop measurements from a
+  // page restored from the back/forward cache: those get a brand-new metric
+  // instance with a new id, which is a distinct, valid measurement we still
+  // want to emit. Scoped to this call so callers that re-init get a fresh
+  // cache instead of inheriting module-level state.
   const reported: Record<string, true> = {};
 
   function report(name: string, metric: webVitalsLib.Metric): void {
-    if (reported[name]) {
+    if (reported[metric.id]) {
       return;
     }
-    reported[name] = true;
+    reported[metric.id] = true;
 
     const now = Date.now();
     const span = tracer.startSpan('webvitals', { startTime: now });
     span.setAttribute(name, metric.value);
+    span.setAttribute('webvitals.navigation_type', metric.navigationType);
+    span.setAttribute('webvitals.metric_id', metric.id);
     span.end(now);
   }
 

--- a/packages/otel-web/test/webvitals.test.ts
+++ b/packages/otel-web/test/webvitals.test.ts
@@ -80,18 +80,61 @@ describe('webvitals', () => {
       callback: CallbackName;
       attribute: string;
       value: number;
+      id: string;
+      navigationType: Metric['navigationType'];
     }> = [
-      { callback: 'onFID', attribute: 'fid', value: 12 },
-      { callback: 'onCLS', attribute: 'cls', value: 0.05 },
-      { callback: 'onLCP', attribute: 'lcp', value: 1234 },
-      { callback: 'onINP', attribute: 'inp', value: 56 },
-      { callback: 'onFCP', attribute: 'fcp', value: 789 },
-      { callback: 'onTTFB', attribute: 'ttfb', value: 100 },
+      {
+        callback: 'onFID',
+        attribute: 'fid',
+        value: 12,
+        id: 'v3-fid',
+        navigationType: 'navigate',
+      },
+      {
+        callback: 'onCLS',
+        attribute: 'cls',
+        value: 0.05,
+        id: 'v3-cls',
+        navigationType: 'reload',
+      },
+      {
+        callback: 'onLCP',
+        attribute: 'lcp',
+        value: 1234,
+        id: 'v3-lcp',
+        navigationType: 'back-forward',
+      },
+      {
+        callback: 'onINP',
+        attribute: 'inp',
+        value: 56,
+        id: 'v3-inp',
+        navigationType: 'back-forward-cache',
+      },
+      {
+        callback: 'onFCP',
+        attribute: 'fcp',
+        value: 789,
+        id: 'v3-fcp',
+        navigationType: 'prerender',
+      },
+      {
+        callback: 'onTTFB',
+        attribute: 'ttfb',
+        value: 100,
+        id: 'v3-ttfb',
+        navigationType: 'restore',
+      },
     ];
 
     for (const c of cases) {
       const cb = fakes[c.callback].firstCall.args[0] as (m: Metric) => void;
-      cb({ name: c.attribute.toUpperCase(), value: c.value } as Metric);
+      cb({
+        name: c.attribute.toUpperCase(),
+        value: c.value,
+        id: c.id,
+        navigationType: c.navigationType,
+      } as Metric);
     }
 
     assert.strictEqual(captured.length, cases.length);
@@ -101,21 +144,66 @@ describe('webvitals', () => {
       );
       assert.ok(span, `Expected a 'webvitals' span carrying '${c.attribute}'`);
       assert.strictEqual(span.attrs[c.attribute], c.value);
+      assert.strictEqual(span.attrs['webvitals.metric_id'], c.id);
+      assert.strictEqual(
+        span.attrs['webvitals.navigation_type'],
+        c.navigationType,
+      );
     }
   });
 
-  it('reports each metric only once even if its callback fires repeatedly', () => {
+  it('reports each metric instance only once even if its callback fires repeatedly', () => {
     const captured: CapturedSpan[] = [];
     const fakes = makeFakeCallbacks();
     initWebVitals(makeCapturingProvider(captured), fakes as never);
 
+    // Same metric instance (same id) firing twice, e.g. an updated CLS value
+    // reported again when the page is hidden a second time.
     const cb = fakes.onLCP.firstCall.args[0] as (m: Metric) => void;
-    cb({ name: 'LCP', value: 1234 } as Metric);
-    cb({ name: 'LCP', value: 5678 } as Metric);
+    cb({ name: 'LCP', value: 1234, id: 'v3-lcp-1' } as Metric);
+    cb({ name: 'LCP', value: 5678, id: 'v3-lcp-1' } as Metric);
 
     const lcpSpans = captured.filter((s) => 'lcp' in s.attrs);
     assert.strictEqual(lcpSpans.length, 1);
     assert.strictEqual(lcpSpans[0].attrs.lcp, 1234);
+  });
+
+  it('emits a separate span for a new metric instance from a bfcache restore', () => {
+    const captured: CapturedSpan[] = [];
+    const fakes = makeFakeCallbacks();
+    initWebVitals(makeCapturingProvider(captured), fakes as never);
+
+    // The back/forward cache restore produces a brand-new metric instance
+    // (new id) for the same metric name. Keying dedup on the name would drop
+    // this valid measurement; keying on the instance id keeps it.
+    const cb = fakes.onLCP.firstCall.args[0] as (m: Metric) => void;
+    cb({
+      name: 'LCP',
+      value: 1234,
+      id: 'v3-lcp-1',
+      navigationType: 'navigate',
+    } as Metric);
+    cb({
+      name: 'LCP',
+      value: 4321,
+      id: 'v3-lcp-2',
+      navigationType: 'back-forward-cache',
+    } as Metric);
+
+    const lcpSpans = captured.filter((s) => 'lcp' in s.attrs);
+    assert.strictEqual(lcpSpans.length, 2);
+    assert.deepStrictEqual(
+      lcpSpans.map((s) => s.attrs.lcp).sort(),
+      [1234, 4321],
+    );
+    assert.deepStrictEqual(
+      lcpSpans.map((s) => s.attrs['webvitals.metric_id']).sort(),
+      ['v3-lcp-1', 'v3-lcp-2'],
+    );
+    assert.deepStrictEqual(
+      lcpSpans.map((s) => s.attrs['webvitals.navigation_type']).sort(),
+      ['back-forward-cache', 'navigate'],
+    );
   });
 });
 
@@ -172,6 +260,7 @@ describe('webvitals (real browser)', function () {
       (fcpSpan.attrs.fcp as number) > 0,
       `FCP should be a positive duration in ms, got ${fcpSpan.attrs.fcp}`,
     );
+    assert.strictEqual(typeof fcpSpan.attrs['webvitals.metric_id'], 'string');
 
     assert.ok(ttfbSpan, 'TTFB span should be emitted');
     assert.strictEqual(ttfbSpan.name, 'webvitals');
@@ -180,5 +269,6 @@ describe('webvitals (real browser)', function () {
       (ttfbSpan.attrs.ttfb as number) >= 0,
       `TTFB should be a non-negative duration in ms, got ${ttfbSpan.attrs.ttfb}`,
     );
+    assert.strictEqual(typeof ttfbSpan.attrs['webvitals.metric_id'], 'string');
   });
 });

--- a/packages/otel-web/test/webvitals.test.ts
+++ b/packages/otel-web/test/webvitals.test.ts
@@ -193,7 +193,9 @@ describe('webvitals', () => {
     const lcpSpans = captured.filter((s) => 'lcp' in s.attrs);
     assert.strictEqual(lcpSpans.length, 2);
     assert.deepStrictEqual(
-      lcpSpans.map((s) => s.attrs.lcp).sort(),
+      lcpSpans
+        .map((s) => s.attrs.lcp)
+        .sort((a, b) => (a as number) - (b as number)),
       [1234, 4321],
     );
     assert.deepStrictEqual(
@@ -261,6 +263,10 @@ describe('webvitals (real browser)', function () {
       `FCP should be a positive duration in ms, got ${fcpSpan.attrs.fcp}`,
     );
     assert.strictEqual(typeof fcpSpan.attrs['webvitals.metric_id'], 'string');
+    assert.strictEqual(
+      typeof fcpSpan.attrs['webvitals.navigation_type'],
+      'string',
+    );
 
     assert.ok(ttfbSpan, 'TTFB span should be emitted');
     assert.strictEqual(ttfbSpan.name, 'webvitals');
@@ -270,5 +276,9 @@ describe('webvitals (real browser)', function () {
       `TTFB should be a non-negative duration in ms, got ${ttfbSpan.attrs.ttfb}`,
     );
     assert.strictEqual(typeof ttfbSpan.attrs['webvitals.metric_id'], 'string');
+    assert.strictEqual(
+      typeof ttfbSpan.attrs['webvitals.navigation_type'],
+      'string',
+    );
   });
 });


### PR DESCRIPTION
Webvitals spans can now be segmented by how the page was visited: each span carries a `webvitals.navigation_type` attribute (`navigate`, `reload`, `back-forward-cache`, etc.) and a per-instance `webvitals.metric_id`. Metric dedup is also keyed on `metric.id` instead of the metric name, so measurements from back/forward-cache restores (which produce a new metric instance with a new id) are no longer silently dropped. Includes unit tests for the new attributes, id-keyed dedup, and the bfcache-restore case, plus a minor changeset for `@hyperdx/otel-web`.

Closes #269

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
