### PR TITLE
feat(browser): expose rrweb blockSelector option

### DIFF
--- a/.changeset/expose-rrweb-block-selector.md
+++ b/.changeset/expose-rrweb-block-selector.md
@@ -1,0 +1,10 @@
+---
+"@hyperdx/browser": minor
+---
+
+Expose the rrweb `blockSelector` option through the browser SDK config. You can
+now pass `blockSelector` to `HyperDX.init(...)` to block session-recording of
+elements matching a CSS selector (complementing the existing `blockClass`). The
+value is forwarded to the session recorder; omit it to keep the previous
+behavior. Improved documentation by adding description for `blockClass` alongside 
+new `blockSelector` property.

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -41,6 +41,12 @@ HyperDX.init({
   replay (default `false`).
 - `maskAllText` - (Optional) Whether to mask all text in session replay (default
   `false`).
+- `blockClass` - (Optional) Elements with this CSS class name are blocked from
+  session replay (their contents are not recorded and render as a placeholder).
+  Use this to exclude sensitive regions from replay.
+- `blockSelector` - (Optional) A CSS selector for elements to block from session
+  replay. Like `blockClass`, but lets you target elements by any selector (ex.
+  `'[data-private], .secret'`) instead of a single class name.
 - `disableIntercom` - (Optional) Whether to disable Intercom integration (default `false`)
 - `otelResourceAttributes` - (Optional) Object containing OpenTelemetry resource attributes to be added to all spans. These are set at the resource level and merged with default SDK attributes. Example:
   ```js

--- a/packages/browser/__tests__/main.test.ts
+++ b/packages/browser/__tests__/main.test.ts
@@ -23,7 +23,12 @@ jest.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
   },
 }));
 
+import SessionRecorder from '@hyperdx/otel-web-session-recorder';
+
 import HyperDX from '../src/index';
+
+// Handle to the mocked SessionRecorder.init (see jest.mock above).
+const mockRecorderInit = SessionRecorder.init as jest.Mock;
 
 // ---------------------------------------------------------------------------
 // SpanCapturer -- mirrors the one in otel-web/test/utils.ts
@@ -260,7 +265,76 @@ describe('Browser SDK (@hyperdx/browser)', () => {
     });
   });
 
-  // -- 9. deinit ----------------------------------------------------------------
+  // -- 9. session recorder config -----------------------------------------------
+  describe('session recorder config', () => {
+    const REPLAY_CONFIG = {
+      apiKey: 'test-api-key',
+      service: 'test-service',
+      disableIntercom: true,
+      disableReplay: false,
+    };
+
+    beforeEach(() => mockRecorderInit.mockClear());
+
+    it('does not init the recorder when replay is disabled', () => {
+      HyperDX.init({ ...REPLAY_CONFIG, disableReplay: true });
+
+      expect(mockRecorderInit).not.toHaveBeenCalled();
+    });
+
+    it('forwards blocking/masking config to SessionRecorder.init', () => {
+      HyperDX.init({
+        ...REPLAY_CONFIG,
+        blockSelector: '.sensitive',
+        blockClass: 'hdx-block',
+        ignoreClass: 'hdx-ignore',
+        maskAllInputs: true,
+        recordCanvas: true,
+      });
+
+      expect(mockRecorderInit).toHaveBeenCalledTimes(1);
+      expect(mockRecorderInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blockSelector: '.sensitive',
+          blockClass: 'hdx-block',
+          ignoreClass: 'hdx-ignore',
+          maskAllInputs: true,
+          recordCanvas: true,
+        }),
+      );
+    });
+
+    it('omits optional selectors when not provided', () => {
+      HyperDX.init(REPLAY_CONFIG);
+
+      expect(mockRecorderInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blockSelector: undefined,
+          blockClass: undefined,
+          maskTextSelector: undefined,
+        }),
+      );
+    });
+
+    // Testing the mapping logic
+    it('maps maskClass onto maskTextClass', () => {
+      HyperDX.init({ ...REPLAY_CONFIG, maskClass: 'hdx-mask' });
+
+      expect(mockRecorderInit).toHaveBeenCalledWith(
+        expect.objectContaining({ maskTextClass: 'hdx-mask' }),
+      );
+    });
+
+    it('maps maskAllText onto a wildcard maskTextSelector', () => {
+      HyperDX.init({ ...REPLAY_CONFIG, maskAllText: true });
+
+      expect(mockRecorderInit).toHaveBeenCalledWith(
+        expect.objectContaining({ maskTextSelector: '*' }),
+      );
+    });
+  });
+
+  // -- 10. deinit ----------------------------------------------------------------
   describe('deinit', () => {
     it('should mark the SDK as not inited after deinit', () => {
       HyperDX.init(MINIMAL_CONFIG);

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -16,6 +16,7 @@ type BrowserSDKConfig = {
   advancedNetworkCapture?: boolean;
   apiKey: string;
   blockClass?: string;
+  blockSelector?: string;
   captureConsole?: boolean; // deprecated
   consoleCapture?: boolean;
   debug?: boolean;
@@ -51,6 +52,7 @@ class Browser {
     advancedNetworkCapture = false,
     apiKey,
     blockClass,
+    blockSelector,
     captureConsole, // deprecated
     consoleCapture,
     debug = false,
@@ -128,6 +130,7 @@ class Browser {
       SessionRecorder.init({
         apiKey,
         blockClass,
+        blockSelector,
         debug,
         ignoreClass,
         maskAllInputs: maskAllInputs,


### PR DESCRIPTION
# Summary

This PR exposes rrweb's blockSelector property to `BrowserSDKConfig` Allowing for consumers to use that property.

This should increase the flexibility for developers to block elements visibility more easily, for instance, blocking all `<img>` tags in PHI / PII sensitive products.

Solves issue https://github.com/hyperdxio/hyperdx-js/issues/281

# How I tested it

- Implemented the fix locally
- Built `@hyperdx/browser`
- added to my project using pnpm link
- Used the new blockSelector with `blockSelector: 'img'`
- Verified that all images once visible are now hidden:
<img width="193" height="121" alt="image" src="https://github.com/user-attachments/assets/d3f7c9c3-081c-4866-b8de-662aa20ab460" />
<img width="169" height="223" alt="image" src="https://github.com/user-attachments/assets/857dcfe7-a5bd-4020-9c47-fa0f5030854d" />



