### PR TITLE
docs: add root README/CONTRIBUTING and improve package docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing
+
+Thanks for your interest in contributing to the HyperDX JavaScript SDKs! This
+guide covers the repository layout and the day-to-day development workflow.
+
+For the detailed code style, naming, and testing conventions, see
+[AGENTS.md](AGENTS.md).
+
+## Repository layout
+
+This is a [Yarn Classic](https://classic.yarnpkg.com/) workspaces monorepo. All
+packages live under `packages/`:
+
+```
+hyperdx-js/
+├── packages/
+│   ├── browser/                     # Browser SDK (wraps otel-web + session-recorder)
+│   ├── cli/                         # CLI for sourcemap uploads
+│   ├── deno/                        # Deno SDK
+│   ├── instrumentation-exception/   # Exception capture instrumentation
+│   ├── instrumentation-sentry-node/ # Sentry integration for OTel
+│   ├── node-logger/                 # Winston/Pino/NestJS logger transports
+│   ├── node-opentelemetry/          # Main Node.js OTel SDK
+│   ├── otel-web/                    # Browser OTel RUM
+│   └── session-recorder/            # Session recording (rrweb-based)
+├── smoke-tests/                     # Docker + BATS integration tests
+├── nx.json                          # Nx workspace config
+└── Makefile                         # Smoke test automation
+```
+
+Tooling:
+
+- **[Nx](https://nx.dev/)** orchestrates builds/tests and respects dependency
+  order between packages.
+- **[Changesets](https://github.com/changesets/changesets)** manages versioning
+  and publishing.
+- Node **v25** is recommended (see `.nvmrc`).
+
+## Getting started
+
+```sh
+# Install dependencies (from the repo root)
+yarn install
+
+# Build all packages
+yarn ci:build
+```
+
+## Building, linting, and testing
+
+Run across all packages from the repo root:
+
+```sh
+yarn ci:build   # npx nx run-many --target=build
+yarn ci:lint    # npx nx run-many --target=ci:lint
+yarn ci:unit    # npx nx run-many --target=ci:unit
+```
+
+Work on a single package:
+
+```sh
+# Build one package
+npx nx run @hyperdx/node-opentelemetry:build
+
+# Or from the package directory
+cd packages/node-opentelemetry && yarn build
+
+# Run one package's tests (most packages use Jest)
+cd packages/node-opentelemetry && npx jest
+
+# Run a single test file / test-name pattern
+cd packages/node-opentelemetry && npx jest --testPathPattern="otel\\.test"
+cd packages/node-opentelemetry && npx jest --testNamePattern="console"
+```
+
+> **Note:** The `otel-web` package uses Karma + Mocha rather than Jest. See its
+> package scripts for the relevant commands.
+
+### Smoke tests (Docker + BATS)
+
+```sh
+make build-smoke-images   # docker compose build
+make smoke-sdk            # run HTTP + gRPC smoke tests
+make smoke                # run all BATS tests
+```
+
+## Code style
+
+- **Prettier** (single quotes, trailing commas) and **ESLint** are enforced via
+  a `husky` + `lint-staged` pre-commit hook.
+- Imports and exports are auto-sorted by `eslint-plugin-simple-import-sort`.
+- TypeScript runs in strict mode.
+
+Run the linters manually from a package directory:
+
+```sh
+yarn lint       # ESLint
+yarn ci:lint    # ESLint + tsc --noEmit
+```
+
+See [AGENTS.md](AGENTS.md) for the full conventions reference.
+
+## Submitting changes
+
+1. [Fork](https://github.com/hyperdxio/hyperdx-js/fork) the repository and clone
+   your fork.
+2. Create a branch for your change.
+3. Make your changes with accompanying tests where applicable.
+4. Add a changeset describing the change (this drives versioning and the
+   changelog):
+   ```sh
+   npx changeset
+   ```
+5. Ensure `yarn ci:build`, `yarn ci:lint`, and `yarn ci:unit` all pass.
+6. Push to your fork and open a pull request against `main`.
+
+## Questions and feedback
+
+Join us in
+[GitHub Discussions](https://github.com/hyperdxio/hyperdx-js/discussions).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# HyperDX JavaScript SDKs
+
+JavaScript/TypeScript SDKs for [HyperDX](https://www.hyperdx.io/), built on
+[OpenTelemetry](https://opentelemetry.io/). This monorepo contains the browser
+and Node.js instrumentation libraries, logger transports, framework
+integrations, and the sourcemap-upload CLI.
+
+## Packages
+
+| Package                                                                         | npm                                                                                                          | Description                                                                   |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| [`node-opentelemetry`](packages/node-opentelemetry/README.md)                   | [`@hyperdx/node-opentelemetry`](https://www.npmjs.com/package/@hyperdx/node-opentelemetry)                   | Main Node.js OpenTelemetry SDK (auto-instrumentation, logs, traces, metrics). |
+| [`node-logger`](packages/node-logger/README.md)                                 | [`@hyperdx/node-logger`](https://www.npmjs.com/package/@hyperdx/node-logger)                                 | Winston, Pino, and NestJS logger transports.                                  |
+| [`browser`](packages/browser/README.md)                                         | [`@hyperdx/browser`](https://www.npmjs.com/package/@hyperdx/browser)                                         | Browser SDK for real user monitoring and session replay.                      |
+| [`otel-web`](packages/otel-web/README.md)                                       | [`@hyperdx/otel-web`](https://www.npmjs.com/package/@hyperdx/otel-web)                                       | OpenTelemetry-based RUM core (consumed via `@hyperdx/browser`).               |
+| [`session-recorder`](packages/session-recorder/README.md)                       | [`@hyperdx/otel-web-session-recorder`](https://www.npmjs.com/package/@hyperdx/otel-web-session-recorder)     | Session recording (consumed via `@hyperdx/browser`).                          |
+| [`instrumentation-exception`](packages/instrumentation-exception/README.md)     | [`@hyperdx/instrumentation-exception`](https://www.npmjs.com/package/@hyperdx/instrumentation-exception)     | Exception capture instrumentation (used internally by the SDKs).              |
+| [`instrumentation-sentry-node`](packages/instrumentation-sentry-node/README.md) | [`@hyperdx/instrumentation-sentry-node`](https://www.npmjs.com/package/@hyperdx/instrumentation-sentry-node) | Bridges `@sentry/node` events into OpenTelemetry.                             |
+| [`cli`](packages/cli/README.md)                                                 | [`@hyperdx/cli`](https://www.npmjs.com/package/@hyperdx/cli)                                                 | Command line tool for uploading sourcemaps.                                   |
+| [`deno`](packages/deno/README.md)                                               | [`@hyperdx/deno`](https://www.npmjs.com/package/@hyperdx/deno)                                               | OpenTelemetry logging support for Deno.                                       |
+
+## Documentation
+
+- Product & setup docs: <https://www.hyperdx.io/docs>
+- OpenTelemetry: <https://opentelemetry.io/>
+
+## Development
+
+This is a [Yarn Classic](https://classic.yarnpkg.com/) workspaces monorepo,
+orchestrated with [Nx](https://nx.dev/) and versioned with
+[Changesets](https://github.com/changesets/changesets). Node `v25` is
+recommended (see `.nvmrc`).
+
+```sh
+# Install dependencies (from the repo root)
+yarn install
+
+# Build, lint, and test all packages (respects dependency order via Nx)
+yarn ci:build
+yarn ci:lint
+yarn ci:unit
+```
+
+To build or test a single package:
+
+```sh
+# Build one package
+npx nx run @hyperdx/node-opentelemetry:build
+
+# Run one package's tests (most packages use Jest)
+cd packages/node-opentelemetry && npx jest
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide, and
+[AGENTS.md](AGENTS.md) for detailed build/test/style reference.
+
+## License
+
+Packages are published under either the MIT or Apache-2.0 license. See the
+`LICENSE` file within each package for details.

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,3 +1,8 @@
+# HyperDX Browser SDK
+
+Browser SDK for [HyperDX](https://www.hyperdx.io/) — real user monitoring
+(RUM), tracing, and session replay for web applications.
+
 ## Getting Started
 
 ### Install
@@ -103,7 +108,7 @@ HyperDX.setGlobalAttributes({
 ### Auto Capture React Error Boundary Errors
 
 If you're using React, you can automatically capture errors that occur within
-React error boundaries by passing your error boundary component 
+React error boundaries by passing your error boundary component
 into the `attachToReactErrorBoundary` function.
 
 ```js
@@ -189,3 +194,6 @@ To retrieve the current session ID, you can call the `getSessionId` function.
 const sessionId = HyperDX.getSessionId();
 ```
 
+## License
+
+Apache 2.0

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,32 +1,75 @@
 # Command Line Interface for HyperDX
 
-## Uploading source maps to HyperDX
+Command line tool for [HyperDX](https://www.hyperdx.io/). Currently supports
+uploading JavaScript sourcemaps so stack traces can be symbolicated in HyperDX.
 
-In your build pipeline, you will need to run the CLI tool. Here's how to run it:
+## Installation
+
+Run on demand with `npx` (no install required):
 
 ```sh
-npx @hyperdx/cli upload-sourcemaps --path="/path/to/sourcemaps" --serviceKey="your-service-account-api-key"
+npx @hyperdx/cli upload-sourcemaps --path /path/to/sourcemaps --serviceKey your-service-account-api-key
 ```
 
-You can also add this as an npm script
+Or install it as a dev dependency:
+
+```sh
+npm install --save-dev @hyperdx/cli
+```
+
+## Uploading source maps
+
+In your build pipeline, run the `upload-sourcemaps` command after your build has
+produced sourcemaps:
+
+```sh
+npx @hyperdx/cli upload-sourcemaps --path /path/to/sourcemaps --serviceKey your-service-account-api-key
+```
+
+You can also add it as an npm script. Set the `HYPERDX_SERVICE_KEY` environment
+variable so you don't have to pass `--serviceKey` on the command line:
 
 ```json
 // In package.json
-
 {
   "scripts": {
-    "upload-sourcemaps": "npx @hyperdx/cli upload-sourcemaps --path=\"/path/to/sourcemaps\""
+    "upload-sourcemaps": "hyperdx upload-sourcemaps --path ./dist"
   }
 }
 ```
 
-Optionally, you can set the `HYPERDX_SERVICE_KEY` environment variable to avoid passing the `serviceKey` flag.
+### Options
+
+| Flag                    | Alias  | Description                                                                                        | Default       |
+| ----------------------- | ------ | -------------------------------------------------------------------------------------------------- | ------------- |
+| `--serviceKey <string>` | `-k`   | The HyperDX service account API key. Falls back to the `HYPERDX_SERVICE_KEY` environment variable. | —             |
+| `--path [string]`       | `-p`   | Directory containing the sourcemaps.                                                               | `.`           |
+| `--apiUrl [string]`     | `-u`   | API URL for self-hosted deployments (e.g. `http://localhost:8000`).                                | HyperDX Cloud |
+| `--releaseId [string]`  | `-rid` | Associate the uploaded sourcemaps with a release id.                                               | —             |
+| `--basePath [string]`   | `-bp`  | Base path to prepend to the uploaded sourcemap paths.                                              | —             |
+| `--apiVersion [string]` |        | The API version to use (`v1` or `v2`).                                                             | `v1`          |
+
+### Self-hosted deployments
+
+Point the CLI at your own collector/API with `--apiUrl`:
+
+```sh
+npx @hyperdx/cli upload-sourcemaps \
+  --path ./dist \
+  --serviceKey your-service-account-api-key \
+  --apiUrl http://localhost:8000
+```
 
 ## Contributing
 
-You can test your changes locally by running the following commands:
+You can test your changes locally by building the package and invoking the
+compiled entry point:
 
 ```sh
 yarn build
-node dist/index.js upload ...
+node dist/index.js upload-sourcemaps --path ./path/to/sourcemaps
 ```
+
+## License
+
+MIT

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -27,3 +27,7 @@ log.setup({
 
 log.getLogger('my-otel-logger').info('Hello from Deno!');
 ```
+
+## License
+
+MIT

--- a/packages/instrumentation-exception/README.md
+++ b/packages/instrumentation-exception/README.md
@@ -1,0 +1,19 @@
+# HyperDX Exception Instrumentation
+
+OpenTelemetry exception capture instrumentation for [HyperDX](https://www.hyperdx.io/).
+
+> **Note:** This package is primarily used internally by
+> [`@hyperdx/node-opentelemetry`](https://www.npmjs.com/package/@hyperdx/node-opentelemetry)
+> and [`@hyperdx/browser`](https://www.npmjs.com/package/@hyperdx/browser). Most
+> users should install one of those SDKs rather than depending on this package
+> directly.
+
+## Installation
+
+```sh
+npm install @hyperdx/instrumentation-exception
+```
+
+## License
+
+Apache 2.0

--- a/packages/instrumentation-sentry-node/README.md
+++ b/packages/instrumentation-sentry-node/README.md
@@ -1,9 +1,9 @@
 # OpenTelemetry Sentry Instrumentation for Node.js
 
 [![NPM Published Version][npm-img]][npm-url]
-[![Apache License][license-image]][license-image]
+[![Apache License][license-image]][license-url]
 
-This module provides automatic instrumentation for the [`@sentry/node`](https://github.com/getsentry/sentry-javascript/tree/develop/packages/node)module.
+This module provides automatic instrumentation for the [`@sentry/node`](https://github.com/getsentry/sentry-javascript/tree/develop/packages/node) module.
 
 Compatible with OpenTelemetry JS API and SDK `1.0+`.
 
@@ -48,4 +48,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [license-url]: https://github.com/hyperdxio/hyperdx-js/blob/main/packages/instrumentation-sentry-node/LICENSE
 [license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
 [npm-url]: https://www.npmjs.com/package/@hyperdx/instrumentation-sentry-node
-[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Finstrumentation-pg.svg
+[npm-img]: https://badge.fury.io/js/%40hyperdx%2Finstrumentation-sentry-node.svg

--- a/packages/node-logger/README.md
+++ b/packages/node-logger/README.md
@@ -28,16 +28,15 @@ This key is necessary for sending logs to your account.
 
 Create a new HyperDX Winston Transport and append it to your list of transports. Example:
 
-```
+```ts
 import winston from 'winston';
 import { HyperDXWinston } from '@hyperdx/node-logger';
 
 const hyperdxTransport = new HyperDXWinston({
-  apiKey: ***HYPERDX_API_KEY***,
+  apiKey: process.env.HYPERDX_API_KEY,
   maxLevel: 'info',
   service: 'my-app',
 });
-
 
 const logger = winston.createLogger({
   level: 'info',
@@ -63,7 +62,7 @@ export default logger;
 
 Create a new HyperDX Pino Transport and append it to your list of transports. Example:
 
-```
+```ts
 import pino from 'pino';
 
 const logger = pino(
@@ -72,7 +71,7 @@ const logger = pino(
       {
         target: '@hyperdx/node-logger/build/src/pino',
         options: {
-          apiKey: ***HYPERDX_API_KEY***,
+          apiKey: process.env.HYPERDX_API_KEY,
           service: 'my-app',
         },
         level: 'info',
@@ -99,14 +98,14 @@ export default logger;
 
 Import HyperDXNestLoggerModule into the root AppModule and use the forRoot() method to configure it.
 
-```
+```ts
 import { Module } from '@nestjs/common';
 import { HyperDXNestLoggerModule } from '@hyperdx/node-logger';
 
 @Module({
   imports: [
     HyperDXNestLoggerModule.forRoot({
-      apiKey: ***HYPERDX_API_KEY***,
+      apiKey: process.env.HYPERDX_API_KEY,
       maxLevel: 'info',
       service: 'my-app',
     }),
@@ -117,16 +116,19 @@ export class AppModule {}
 
 Afterward, the winston instance will be available to inject across entire project using the `HDX_LOGGER_MODULE_PROVIDER` injection token:
 
-```
+```ts
 import { Controller, Inject } from '@nestjs/common';
-import { HyperDXNestLoggerModule, HyperDXNestLogger } from '@hyperdx/node-logger';
+import {
+  HyperDXNestLoggerModule,
+  HyperDXNestLogger,
+} from '@hyperdx/node-logger';
 
 @Controller('cats')
 export class CatsController {
   constructor(
     @Inject(HyperDXNestLoggerModule.HDX_LOGGER_MODULE_PROVIDER)
     private readonly logger: HyperDXNestLogger,
-  ) { }
+  ) {}
 
   meow() {
     this.logger.info({ message: '🐱' });
@@ -149,16 +151,16 @@ Nest will then wrap our custom logger (the same instance returned by the createL
 
 Create the logger in the `main.ts` file
 
-```
+```ts
 import { HyperDXNestLoggerModule } from '@hyperdx/node-logger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger: HyperDXNestLoggerModule.createLogger({
-      apiKey: ***HYPERDX_API_KEY***,
+      apiKey: process.env.HYPERDX_API_KEY,
       maxLevel: 'info',
       service: 'my-app',
-    })
+    }),
   });
   await app.listen(3000);
 }
@@ -167,7 +169,7 @@ bootstrap();
 
 Change your main module to provide the Logger service:
 
-```
+```ts
 import { Logger, Module } from '@nestjs/common';
 
 @Module({
@@ -178,7 +180,7 @@ export class AppModule {}
 
 Then inject the logger simply by type hinting it with Logger from @nestjs/common:
 
-```
+```ts
 import { Controller, Logger } from '@nestjs/common';
 
 @Controller('cats')

--- a/packages/node-opentelemetry/README.md
+++ b/packages/node-opentelemetry/README.md
@@ -106,11 +106,12 @@ import { initSDK } from '@hyperdx/node-opentelemetry';
 initSDK({
   consoleCapture: true, // optional, default: true
   additionalInstrumentations: [], // optional, default: []
-  additionalResourceAttributes: { // optional, default: {}
+  additionalResourceAttributes: {
+    // optional, default: {}
     // Add custom resource attributes to all telemetry data
-    'environment': 'production',
+    environment: 'production',
     'deployment.version': '1.0.0',
-    'custom.attribute': 'value'
+    'custom.attribute': 'value',
   },
 });
 
@@ -185,7 +186,7 @@ initSDK({
     'cloud.region': process.env.AWS_REGION,
     // Add any custom attributes your organization needs
     'team.name': 'backend-team',
-    'feature.flag': 'new-checkout-flow'
+    'feature.flag': 'new-checkout-flow',
   },
 });
 ```
@@ -286,3 +287,7 @@ functions.cloudEvent(
   }),
 );
 ```
+
+## License
+
+MIT

--- a/packages/otel-web/README.md
+++ b/packages/otel-web/README.md
@@ -1,1 +1,21 @@
 # OpenTelemetry-based Real User Monitoring (RUM) for Web
+
+HyperDX distribution of OpenTelemetry for real user monitoring (RUM). This
+package provides the browser tracing and telemetry core for
+[HyperDX](https://www.hyperdx.io/).
+
+> **Note:** This package is consumed by
+> [`@hyperdx/browser`](https://www.npmjs.com/package/@hyperdx/browser), which is
+> the recommended entry point for instrumenting a web application. Install and
+> configure `@hyperdx/browser` unless you specifically need the lower-level RUM
+> core.
+
+## Installation
+
+```sh
+npm install @hyperdx/otel-web
+```
+
+## License
+
+Apache 2.0

--- a/packages/session-recorder/README.md
+++ b/packages/session-recorder/README.md
@@ -1,1 +1,21 @@
 # OpenTelemetry-based Session Recording for Web
+
+HyperDX distribution of OpenTelemetry-based session recording. This package
+powers session replay for [HyperDX](https://www.hyperdx.io/) using
+[rrweb](https://www.rrweb.io/).
+
+> **Note:** This package is consumed by
+> [`@hyperdx/browser`](https://www.npmjs.com/package/@hyperdx/browser), which is
+> the recommended entry point for enabling session replay in a web application.
+> Install and configure `@hyperdx/browser` unless you specifically need the
+> lower-level session recorder.
+
+## Installation
+
+```sh
+npm install @hyperdx/otel-web-session-recorder
+```
+
+## License
+
+Apache 2.0


### PR DESCRIPTION
## Summary

The repo had no landing page and no contributor guide, three published packages shipped with empty or single-line READMEs (so their npm pages were blank), and the CLI README documented a command that doesn't exist. This adds the missing top-level docs and brings every package README up to a consistent baseline.

## What changed

- **Root `README.md`** (new) — monorepo landing page: a table of all 9 packages linking to their npm pages and READMEs, docs links, and a Development section using the real root scripts.
- **`CONTRIBUTING.md`** (new) — contributor guide covering repo layout, the Nx/Changesets workflow, single-package build/test commands, and a fork-based PR flow. Defers to `AGENTS.md` for detailed style rules rather than duplicating them.
- **Empty/stub package READMEs filled** — `instrumentation-exception` (was 0 bytes), `otel-web`, and `session-recorder` (were title-only) now have an install command and a pointer to the package that consumes them (`@hyperdx/browser` / `@hyperdx/node-opentelemetry`). Kept minimal since these are internally consumed rather than direct-use APIs.
- **CLI README corrected** — the documented `upload` command is actually `upload-sourcemaps`; added a full flag table (verified against `packages/cli/src/index.ts`), `HYPERDX_SERVICE_KEY` usage, and a self-hosted example.
- **Consistency fixes** — replaced invalid `***HYPERDX_API_KEY***` placeholders in `node-logger` with `process.env.HYPERDX_API_KEY` and tagged its code fences; fixed the `instrumentation-sentry-node` npm badge (pointed at `instrumentation-pg`) and license link; added a title/description header and license footers across packages that lacked them.

## Test plan

Docs-only change. Ran Prettier over all touched Markdown files to conform to the repo's formatting hook.
