### PR TITLE
feat(otel-web): emit JS heap sizes on documentLoad spans

### DIFF
--- a/.changeset/otel-web-memory-attributes.md
+++ b/.changeset/otel-web-memory-attributes.md
@@ -1,0 +1,10 @@
+---
+"@hyperdx/otel-web": minor
+---
+
+`documentLoad` spans now carry the browser's JS heap sizes as
+`performance.memory.usedJSHeapSize`, `performance.memory.totalJSHeapSize`, and
+`performance.memory.jsHeapSizeLimit` (bytes), enabling per-page memory analysis.
+The values come from the non-standard `performance.memory` API and are
+feature-detected, so they are emitted only on Chromium-based browsers and
+omitted on Firefox/Safari, alongside the existing `screen.xy` tag.

--- a/packages/otel-web/src/SplunkDocumentLoadInstrumentation.ts
+++ b/packages/otel-web/src/SplunkDocumentLoadInstrumentation.ts
@@ -33,6 +33,14 @@ export interface SplunkDocLoadInstrumentationConfig
 
 const excludedInitiatorTypes = ['beacon', 'fetch', 'xmlhttprequest'];
 
+// `performance.memory` is a non-standard, Chromium-only API and is not part of the
+// standard DOM lib types, so we declare the shape we read here (values are in bytes).
+interface PerformanceMemory {
+  usedJSHeapSize: number;
+  totalJSHeapSize: number;
+  jsHeapSizeLimit: number;
+}
+
 function addExtraDocLoadTags(span: api.Span) {
   if (document.referrer && document.referrer !== '') {
     span.setAttribute('document.referrer', document.referrer);
@@ -41,6 +49,23 @@ function addExtraDocLoadTags(span: api.Span) {
     span.setAttribute(
       'screen.xy',
       window.screen.width + 'x' + window.screen.height,
+    );
+  }
+  // Chromium-only; absent in Firefox/Safari, so feature-detect before reading.
+  const memory = (performance as Performance & { memory?: PerformanceMemory })
+    .memory;
+  if (memory) {
+    span.setAttribute(
+      'performance.memory.usedJSHeapSize',
+      memory.usedJSHeapSize,
+    );
+    span.setAttribute(
+      'performance.memory.totalJSHeapSize',
+      memory.totalJSHeapSize,
+    );
+    span.setAttribute(
+      'performance.memory.jsHeapSizeLimit',
+      memory.jsHeapSizeLimit,
     );
   }
 }

--- a/packages/otel-web/test/init.test.ts
+++ b/packages/otel-web/test/init.test.ts
@@ -149,6 +149,35 @@ describe('test init', () => {
           ),
         );
 
+        // `performance.memory` is Chromium-only; the heap attributes should be
+        // present (as numbers) when the API exists and absent otherwise, matching
+        // the feature-detect guard in addExtraDocLoadTags.
+        const memory = (
+          performance as Performance & { memory?: Record<string, number> }
+        ).memory;
+        const heapKeys = [
+          'performance.memory.usedJSHeapSize',
+          'performance.memory.totalJSHeapSize',
+          'performance.memory.jsHeapSizeLimit',
+        ];
+        if (memory) {
+          heapKeys.forEach((key) => {
+            assert.strictEqual(
+              typeof documentLoadSpan.attributes[key],
+              'number',
+              `${key} should be a number when performance.memory is available`,
+            );
+          });
+        } else {
+          heapKeys.forEach((key) => {
+            assert.strictEqual(
+              documentLoadSpan.attributes[key],
+              undefined,
+              `${key} should be absent when performance.memory is unavailable`,
+            );
+          });
+        }
+
         const resourceFetchSpan = capturer.spans.find(
           (span) => span.name === 'resourceFetch',
         );


### PR DESCRIPTION
## What

Adds the browser's JS heap sizes to the `documentLoad` span emitted by `SplunkDocumentLoadInstrumentation`, right beside the existing `screen.xy` tag:

- `performance.memory.usedJSHeapSize`
- `performance.memory.totalJSHeapSize`
- `performance.memory.jsHeapSizeLimit`

Values are raw **bytes**. This enables per-page memory analysis in the HyperDX backend.

## Why

There was no way to see per-page memory usage in browser RUM. `addExtraDocLoadTags` already runs exactly once per page for the `documentLoad` span and is the established home for browser-environment tags (`document.referrer`, `screen.xy`), so the heap metrics slot in there and mirror that pattern one-for-one.

## Browser support (important caveat)

`performance.memory` is a **non-standard, Chromium-only** API. Firefox and Safari do not expose per-page memory (fingerprinting/privacy), and **no cross-browser alternative exists** — `measureUserAgentSpecificMemory()` and `navigator.deviceMemory` are also Chromium-only. So the values are **feature-detected** (same guard style as `if (window.screen)`) and simply omitted on non-Chromium browsers; the span still exports cleanly there. This matches how Grafana Faro captures heap metrics.

## Naming

No ratified OTel semantic convention exists for browser JS heap, so the attribute keys mirror the Web Performance API path — consistent with this file's flat-dotted style (`screen.xy`) and keeping the familiar `usedJSHeapSize`/`totalJSHeapSize`/`jsHeapSizeLimit` names as the final segment.

## Testing

- Extended the existing doc-load unit test (`packages/otel-web/test/init.test.ts`): asserts the three attributes are present as numbers when `performance.memory` exists and absent otherwise, validating the feature-detect guard (same idiom as the file's existing `screen.xy` / Firefox guard).
- `karma` ChromeHeadless: **67 pass / 0 fail** (8 pre-existing skips). ChromeHeadless exposes `performance.memory`, so the "present" branch ran and confirmed emission.
- `nx build @hyperdx/otel-web` (tsc) ✅ · test-config type-check ✅ · Prettier ✅.

Additive, single-seam change with a minor changeset for `@hyperdx/otel-web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)