### PR TITLE
fix(session-recorder): prevent unbounded error loop from corrupted TextDecoder in emit

### DIFF
--- a/.changeset/session-recorder-decoder-crash-loop.md
+++ b/.changeset/session-recorder-decoder-crash-loop.md
@@ -1,0 +1,16 @@
+---
+"@hyperdx/otel-web-session-recorder": patch
+---
+
+Fixed an unbounded uncaught-error loop in the session recorder on Safari
+(hyperdxio/hyperdx-js#303). WebKit's `TextDecoder` can permanently corrupt
+after high cumulative decode volume and then throw `RangeError: Bad value` on
+valid input (https://bugs.webkit.org/show_bug.cgi?id=286266); the recorder
+reused one module-level decoder in `emit()` with no error handling, so a
+single corrupted instance turned every rrweb flush into an uncaught error
+until page unload. Single-chunk events (the common case) now skip the
+encode/decode round-trip entirely, multi-chunk events use a fresh per-event
+decoder with `{ stream: true }` (also fixing U+FFFD corruption when a chunk
+boundary bisected a multi-byte character), a failed decode is retried once
+with a new decoder, and the recorder stops after 10 consecutive emit failures
+instead of erroring on every event forever.

--- a/packages/session-recorder/__tests__/emit.test.ts
+++ b/packages/session-recorder/__tests__/emit.test.ts
@@ -1,0 +1,163 @@
+import type { eventWithTime } from '@rrweb/types';
+
+// MutationRateLimiter starts a setInterval that is never cleared; fake
+// timers keep it from holding the jest process open
+jest.useFakeTimers();
+jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+const mockOnLog = jest.fn();
+const mockStopRecording = jest.fn();
+let capturedEmit: ((event: eventWithTime) => void) | undefined;
+
+jest.mock('rrweb', () => ({
+  record: Object.assign(
+    jest.fn((options: { emit: (event: eventWithTime) => void }) => {
+      capturedEmit = options.emit;
+      return mockStopRecording;
+    }),
+    {
+      takeFullSnapshot: jest.fn(),
+      mirror: { getNode: jest.fn(), getId: jest.fn() },
+    },
+  ),
+}));
+
+jest.mock('../src/OTLPLogExporter', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../src/BatchLogProcessor', () => ({
+  BatchLogProcessor: jest.fn().mockImplementation(() => ({ onLog: mockOnLog })),
+  convert: jest.fn((body: string) => ({ body })),
+}));
+
+jest.mock('@opentelemetry/api', () => {
+  const actual = jest.requireActual('@opentelemetry/api');
+  const span = {
+    isRecording: () => true,
+    setAttribute: jest.fn(),
+    end: jest.fn(),
+  };
+  return {
+    ...actual,
+    trace: {
+      ...actual.trace,
+      getTracerProvider: () => ({
+        resource: { attributes: { 'rum.sessionId': 'session-1' } },
+      }),
+      getTracer: () => ({ startSpan: () => span }),
+    },
+  };
+});
+
+jest.mock('../src/sessionrecording-utils', () => {
+  const actual = jest.requireActual('../src/sessionrecording-utils');
+  return { ...actual, splitIntoChunks: jest.fn(actual.splitIntoChunks) };
+});
+
+import { diag } from '@opentelemetry/api';
+
+import RumRecorder from '../src';
+import { splitIntoChunks } from '../src/sessionrecording-utils';
+
+const mockSplitIntoChunks = splitIntoChunks as jest.Mock;
+
+const emitEvent = () =>
+  capturedEmit!({
+    type: 4,
+    data: {},
+    timestamp: Date.now(),
+  } as eventWithTime);
+
+const failEmit = () =>
+  mockSplitIntoChunks.mockImplementation(() => {
+    throw new RangeError('Bad value');
+  });
+
+const restoreEmit = () =>
+  mockSplitIntoChunks.mockImplementation(
+    jest.requireActual('../src/sessionrecording-utils').splitIntoChunks,
+  );
+
+describe('emit error handling', () => {
+  let diagError: jest.SpyInstance;
+
+  beforeAll(() => {
+    // init() bails outside the browser; a bare window/document is enough
+    // for the code paths under test
+    (global as any).window = {};
+    (global as any).document = { hidden: false };
+    diagError = jest.spyOn(diag, 'error').mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    RumRecorder.deinit();
+    jest.clearAllMocks();
+    restoreEmit();
+    RumRecorder.init({});
+  });
+
+  afterAll(() => {
+    diagError.mockRestore();
+    delete (global as any).window;
+    delete (global as any).document;
+  });
+
+  it('processes events while emit succeeds', () => {
+    expect(capturedEmit).toBeInstanceOf(Function);
+    emitEvent();
+    expect(mockOnLog).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows emit failures instead of throwing into rrweb', () => {
+    failEmit();
+    for (let i = 0; i < 9; i++) {
+      expect(emitEvent).not.toThrow();
+    }
+    expect(mockOnLog).not.toHaveBeenCalled();
+    expect(mockStopRecording).not.toHaveBeenCalled();
+    // every dropped event is surfaced, but the breaker has not tripped
+    expect(diagError).toHaveBeenCalledTimes(9);
+    expect(diagError).not.toHaveBeenCalledWith(
+      expect.stringContaining('stopping recording'),
+      expect.anything(),
+    );
+  });
+
+  it('stops recording after 10 consecutive failures', () => {
+    failEmit();
+    for (let i = 0; i < 10; i++) {
+      expect(emitEvent).not.toThrow();
+    }
+    expect(mockStopRecording).toHaveBeenCalledTimes(1);
+    expect(diagError).toHaveBeenCalledWith(
+      expect.stringContaining('stopping recording'),
+      expect.any(RangeError),
+    );
+  });
+
+  it('emits nothing after the circuit breaker trips', () => {
+    failEmit();
+    for (let i = 0; i < 10; i++) {
+      emitEvent();
+    }
+    restoreEmit();
+    emitEvent();
+    expect(mockOnLog).not.toHaveBeenCalled();
+  });
+
+  it('records again after a re-init following a breaker trip', () => {
+    failEmit();
+    for (let i = 0; i < 10; i++) {
+      emitEvent();
+    }
+    expect(RumRecorder.inited).toBe(false);
+
+    restoreEmit();
+    RumRecorder.init({});
+    emitEvent();
+    expect(mockOnLog).toHaveBeenCalledTimes(1);
+    expect(mockStopRecording).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/session-recorder/__tests__/sessionrecording-utils.test.ts
+++ b/packages/session-recorder/__tests__/sessionrecording-utils.test.ts
@@ -1,0 +1,47 @@
+import { splitIntoChunks } from '../src/sessionrecording-utils';
+
+describe('splitIntoChunks', () => {
+  it('returns the string as-is when it fits in one chunk', () => {
+    const s = 'hello';
+    expect(splitIntoChunks(s, 1024)).toEqual([s]);
+  });
+
+  it('splits large payloads and reassembles losslessly', () => {
+    const s = 'x'.repeat(25);
+    const chunks = splitIntoChunks(s, 10);
+    expect(chunks.length).toBe(3);
+    expect(chunks.join('')).toBe(s);
+  });
+
+  it('retries once with a fresh decoder when decoding throws', () => {
+    const RealTextDecoder = global.TextDecoder;
+    let constructed = 0;
+    // First decoder instance always throws (mimics WebKit's corrupted
+    // TextDecoder, https://bugs.webkit.org/show_bug.cgi?id=286266)
+    class FlakyTextDecoder extends RealTextDecoder {
+      private broken = ++constructed === 1;
+      decode(...args: Parameters<TextDecoder['decode']>): string {
+        if (this.broken) {
+          throw new RangeError('Bad value');
+        }
+        return super.decode(...args);
+      }
+    }
+    global.TextDecoder = FlakyTextDecoder as typeof TextDecoder;
+    try {
+      const s = 'x'.repeat(25);
+      expect(splitIntoChunks(s, 10).join('')).toBe(s);
+      expect(constructed).toBe(2);
+    } finally {
+      global.TextDecoder = RealTextDecoder;
+    }
+  });
+
+  it('does not corrupt multi-byte characters at chunk boundaries', () => {
+    // '€' is 3 bytes in UTF-8; a 10-byte chunk size bisects it
+    const s = '€'.repeat(10);
+    const chunks = splitIntoChunks(s, 10);
+    expect(chunks.join('')).toBe(s);
+    expect(chunks.join('')).not.toContain('�');
+  });
+});

--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import {
+  diag,
   ProxyTracerProvider,
   TracerProvider,
   trace,
@@ -31,6 +32,7 @@ import type { Resource } from '@opentelemetry/resources';
 import {
   MutationRateLimiter,
   ensureStringifiedMaxMessageSize,
+  splitIntoChunks,
 } from './sessionrecording-utils';
 
 interface BasicTracerProvider extends TracerProvider {
@@ -53,8 +55,9 @@ export type RumRecorderConfig = RRWebOptions & {
 // Hard limit of 4 hours of maximum recording during one session
 const MAX_RECORDING_LENGTH = (4 * 60 + 1) * 60 * 1000;
 const MAX_CHUNK_SIZE = 950 * 1024; // ~950KB
-const encoder = new TextEncoder();
-const decoder = new TextDecoder();
+// Stop recording instead of erroring on every rrweb flush forever if emit
+// keeps failing (e.g. a corrupted WebKit TextDecoder, see splitIntoChunks)
+const maxConsecutiveEmitFailures = 10;
 
 let inited: (() => void) | false | undefined = false;
 let tracer: Tracer;
@@ -65,6 +68,7 @@ let eventCounter = 1;
 let logCounter = 1;
 let mutationRateLimiter: MutationRateLimiter | undefined;
 let queuedFullSnapshotTimeout;
+let consecutiveEmitFailures = 0;
 
 const RumRecorder = {
   get inited(): boolean {
@@ -156,6 +160,11 @@ const RumRecorder = {
         },
       });
 
+    // A previous breaker trip (or stop()) must not leak into this
+    // recording lifetime
+    paused = false;
+    consecutiveEmitFailures = 0;
+
     inited = record({
       maskAllInputs: true,
       maskTextSelector: '*',
@@ -194,30 +203,61 @@ const RumRecorder = {
 
         const time = event.timestamp;
         const eventI = eventCounter++;
-        // Research found that stringifying the rr-web event here is
-        // more efficient for otlp + gzip exporting
-
-        // Blob is unicode aware for size calculation (eg emoji.length = 1 vs blob.size() = 4)
-        const body = encoder.encode(
-          ensureStringifiedMaxMessageSize(JSON.stringify(event)),
-        );
-        const totalC = Math.ceil(body.byteLength / MAX_CHUNK_SIZE);
-        for (let i = 0; i < totalC; i++) {
-          const start = i * MAX_CHUNK_SIZE;
-          const end = (i + 1) * MAX_CHUNK_SIZE;
-          const log = convert(decoder.decode(body.slice(start, end)), time, {
-            'rr-web.offset': logCounter++,
-            'rr-web.event': eventI,
-            'rr-web.chunk': i + 1,
-            'rr-web.total-chunks': totalC,
-          });
-          if (debug) {
-            console.log(log);
+        try {
+          // Research found that stringifying the rr-web event here is
+          // more efficient for otlp + gzip exporting
+          const chunks = splitIntoChunks(
+            ensureStringifiedMaxMessageSize(JSON.stringify(event)),
+            MAX_CHUNK_SIZE,
+          );
+          // Convert every chunk before sending any, so a mid-loop failure
+          // can't export a partial (unreassemblable) chunk set
+          const logs = chunks.map((chunk, i) =>
+            convert(chunk, time, {
+              'rr-web.offset': logCounter++,
+              'rr-web.event': eventI,
+              'rr-web.chunk': i + 1,
+              'rr-web.total-chunks': chunks.length,
+            }),
+          );
+          for (const log of logs) {
+            if (debug) {
+              console.log(log);
+            }
+            processor.onLog(log);
           }
-          processor.onLog(log);
+          consecutiveEmitFailures = 0;
+        } catch (e) {
+          consecutiveEmitFailures++;
+          // Each failure drops a whole rrweb event always surface it
+          diag.error('OpenTelemetry Session Recorder: emit failed', e);
+          if (consecutiveEmitFailures >= maxConsecutiveEmitFailures) {
+            diag.error(
+              'OpenTelemetry Session Recorder: stopping recording after repeated errors',
+              e,
+            );
+            paused = true;
+            try {
+              RumRecorder.deinit();
+            } catch (stopError) {
+              // rrweb's stop() can throw when called from inside its own
+              // emit; never let that escape back into rrweb
+              diag.error(
+                'OpenTelemetry Session Recorder: failed to stop recording',
+                stopError,
+              );
+            }
+          }
         }
       },
     });
+
+    // If the breaker tripped during rrweb's synchronous initial snapshot,
+    // the deinit() above was a no-op (`inited` was still unset) finish
+    // the teardown now that we hold the stop function
+    if (consecutiveEmitFailures >= maxConsecutiveEmitFailures) {
+      RumRecorder.deinit();
+    }
   },
   resume(): void {
     if (!inited) {
@@ -247,8 +287,10 @@ const RumRecorder = {
       return;
     }
 
-    inited();
+    // Clear `inited` first so state stays consistent even if stop throws
+    const stopRecording = inited;
     inited = false;
+    stopRecording();
   },
 };
 

--- a/packages/session-recorder/src/sessionrecording-utils.ts
+++ b/packages/session-recorder/src/sessionrecording-utils.ts
@@ -85,6 +85,61 @@ export declare type recordOptions<T> = {
 };
 
 /*
+ * Split a serialized event into chunks of roughly maxChunkSize bytes
+ * (UTF-8): a chunk can exceed it by up to 3 bytes when a multi-byte
+ * character spans a chunk boundary (the streaming decoder defers the
+ * character to the following chunk), so callers must leave a few bytes
+ * of headroom below any hard payload limit. A single-chunk payload is
+ * returned as-is without any encode/decode round-trip this keeps the
+ * hot path off TextDecoder entirely, which matters because WebKit's
+ * TextDecoder can permanently corrupt after high cumulative decode
+ * volume and then throw `RangeError: Bad value` on valid input
+ * (https://bugs.webkit.org/show_bug.cgi?id=286266).
+ * For multi-chunk payloads a fresh TextDecoder is used per call, with
+ * `{ stream: true }` so multi-byte characters spanning a chunk boundary
+ * aren't mangled into U+FFFD replacement characters. If decoding still
+ * throws, it is retried once from the start with another new decoder.
+ */
+export function splitIntoChunks(
+  serialized: string,
+  maxChunkSize: number,
+): string[] {
+  // 3 bytes is the max UTF-8 width of a single UTF-16 code unit, so this
+  // proves the common small event fits in one chunk without paying for a
+  // full encode on every rrweb flush
+  if (serialized.length * 3 <= maxChunkSize) {
+    return [serialized];
+  }
+  const body = new TextEncoder().encode(serialized);
+  const totalChunks = Math.ceil(body.byteLength / maxChunkSize);
+  if (totalChunks <= 1) {
+    return [serialized];
+  }
+  const decodeAll = (): string[] => {
+    const chunkDecoder = new TextDecoder();
+    const chunks: string[] = [];
+    for (let i = 0; i < totalChunks; i++) {
+      chunks.push(
+        chunkDecoder.decode(
+          body.slice(i * maxChunkSize, (i + 1) * maxChunkSize),
+          {
+            stream: i < totalChunks - 1,
+          },
+        ),
+      );
+    }
+    return chunks;
+  };
+  try {
+    return decodeAll();
+  } catch (e) {
+    // Restart from chunk 0 with a brand-new decoder so the streaming
+    // state stays consistent
+    return decodeAll();
+  }
+}
+
+/*
  * Check whether a data payload is nearing 5mb. If it is, it checks the data for
  * data URIs (the likely culprit for large payloads). If it finds data URIs, it either replaces
  * it with a generic image (if it's an image) or removes it.


### PR DESCRIPTION
Fixes #303

## Problem

On Safari, the session recorder's `emit()` could enter a permanent, unbounded error loop: WebKit's `TextDecoder` can permanently corrupt after high cumulative decode volume and then throw `RangeError: Bad value` on valid input ([WebKit #286266](https://bugs.webkit.org/show_bug.cgi?id=286266), [wasm-bindgen report](https://github.com/wasm-bindgen/wasm-bindgen/discussions/4185)). `emit()` reused one module-level decoder for the page lifetime with no error handling, so a single corrupted instance turned every rrweb mutation flush into an uncaught error (~40/sec, observed 64,606 errors over 26 minutes from one session) until page unload. Full telemetry in #303.

## Changes

- **Single-chunk events (the overwhelmingly common case) skip the encode→decode round-trip entirely** the JSON string is already in hand, so most events never touch `TextDecoder`. This also removes the cumulative decode volume that ages the decoder toward WebKit's corruption threshold.
- **Multi-chunk events use a fresh per-event `TextDecoder` with `{ stream: true }`**, which also fixes a latent all-browser bug: byte-slice boundaries that bisected a multi-byte UTF-8 character previously produced U+FFFD replacement characters at chunk seams, silently corrupting reassembled replay JSON.
- **A failed decode is retried once** with a new decoder, restarting from chunk 0 so streaming state stays consistent.
- **Circuit breaker:** `emit()` failures are caught (each dropped event is surfaced via `console.error`), and after 10 consecutive failures the recorder stops instead of erroring on every event forever. `init()` resets the breaker state so a later recording lifetime starts clean.
- Chunks are all converted before any is sent, so a mid-loop failure can't export a partial, unreassemblable chunk set.

## Tests

- `splitIntoChunks` unit tests: single-chunk identity (no decode), lossless multi-chunk reassembly, a multi-byte character bisected at the chunk boundary (fails against the old non-streaming decode), and recovery via the fresh-decoder retry (first decoder instance always throws `RangeError: Bad value`).
- `emit()` error-handling tests (mocked rrweb/exporter/tracer): failures don't throw into rrweb dispatch, the breaker trips on the 10th consecutive failure and stops recording, nothing is emitted after tripping, and recording works again after a re-init.

`compile:tsc` clean, `jest` 10/10 passing.

## Notes

- Includes a changeset (patch bump for `@hyperdx/otel-web-session-recorder`).
- Pre-existing and untouched here: `MutationRateLimiter`'s constructor starts a `setInterval` that is never cleared (it also survives `deinit()`); the emit tests use fake timers to work around it. Happy to fix in a follow-up.
