### PR TITLE
fix(session-recorder): replace deprecated unload listener with visibilitychange/pagehide

### DIFF
--- a/.changeset/session-recorder-remove-unload.md
+++ b/.changeset/session-recorder-remove-unload.md
@@ -1,0 +1,6 @@
+---
+'@hyperdx/otel-web-session-recorder': patch
+'@hyperdx/browser': patch
+---
+
+Replace the deprecated `unload` listener in the session recorder's log processor with `visibilitychange` (hidden) and `pagehide`, and send end-of-session flushes with `fetch` `keepalive` so they survive page termination. This removes the Chrome Permissions Policy violation warning and no longer makes pages ineligible for the back/forward cache.

--- a/packages/session-recorder/src/BatchLogProcessor.ts
+++ b/packages/session-recorder/src/BatchLogProcessor.ts
@@ -34,7 +34,16 @@ export class BatchLogProcessor {
     this.scheduledDelayMillis = config?.scheduledDelayMillis || 5000;
     this.exporter = exporter;
 
-    window.addEventListener('unload', () => {
+    // Flush on visibilitychange/pagehide instead of the deprecated unload
+    // event, which Chrome blocks via Permissions Policy and which makes the
+    // page ineligible for the back/forward cache.
+    // https://developer.chrome.com/docs/web-platform/deprecating-unload
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        this._flushAll();
+      }
+    });
+    window.addEventListener('pagehide', () => {
       this._flushAll();
     });
   }

--- a/packages/session-recorder/src/OTLPLogExporter.ts
+++ b/packages/session-recorder/src/OTLPLogExporter.ts
@@ -136,10 +136,16 @@ export default class OTLPLogExporter {
       ? Object.assign({}, defaultHeaders, this.config.headers)
       : defaultHeaders;
 
+    // keepalive lets the request outlive the page on pagehide/visibility
+    // flushes, but its body limit is 64 KiB, so guard on the payload size.
+    const keepalive =
+      compressed.byteLength < 65536 && document.visibilityState === 'hidden';
+
     fetch(this.config.beaconUrl, {
       method: 'POST',
       body: compressed,
       headers: updatedHeaders,
+      keepalive,
     }).catch(() => {
       // TODO remove this once we have ingest with correct cors headers
     });

--- a/packages/session-recorder/test/BatchLogProcessor.test.ts
+++ b/packages/session-recorder/test/BatchLogProcessor.test.ts
@@ -1,0 +1,74 @@
+import { BatchLogProcessor, convert } from '../src/BatchLogProcessor';
+import type { LogExporter } from '../src/types';
+
+describe('BatchLogProcessor', () => {
+  let listeners: Record<string, Array<() => void>>;
+  let visibilityState: string;
+  let exported: unknown[][];
+  let exporter: LogExporter;
+
+  const dispatch = (type: string) => {
+    (listeners[type] || []).forEach((listener) => listener());
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    listeners = {};
+    visibilityState = 'visible';
+    exported = [];
+    exporter = {
+      export: (logs) => {
+        exported.push(logs);
+      },
+    } as LogExporter;
+
+    const addEventListener = (type: string, listener: () => void) => {
+      (listeners[type] = listeners[type] || []).push(listener);
+    };
+    (globalThis as any).window = { addEventListener };
+    (globalThis as any).document = {
+      addEventListener,
+      get visibilityState() {
+        return visibilityState;
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+  });
+
+  it('does not register a deprecated unload listener', () => {
+    new BatchLogProcessor(exporter, {});
+
+    expect(listeners['unload']).toBeUndefined();
+    expect(listeners['beforeunload']).toBeUndefined();
+    expect(listeners['pagehide']).toHaveLength(1);
+    expect(listeners['visibilitychange']).toHaveLength(1);
+  });
+
+  it('flushes queued logs on pagehide', () => {
+    const processor = new BatchLogProcessor(exporter, {});
+    processor.onLog(convert('test-log', 1));
+
+    dispatch('pagehide');
+
+    expect(exported).toHaveLength(1);
+    expect(exported[0]).toHaveLength(1);
+  });
+
+  it('flushes queued logs when the page becomes hidden', () => {
+    const processor = new BatchLogProcessor(exporter, {});
+    processor.onLog(convert('test-log', 1));
+
+    dispatch('visibilitychange');
+    expect(exported).toHaveLength(0);
+
+    visibilityState = 'hidden';
+    dispatch('visibilitychange');
+    expect(exported).toHaveLength(1);
+    expect(exported[0]).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the deprecated `unload` listener in the session recorder's `BatchLogProcessor` with `visibilitychange` (hidden) + `pagehide` — the same flush strategy `HyperDXBatchSpanProcessor` already uses for spans
- Send the flush with fetch `keepalive` (when under the 64 KiB body limit) so the final request survives page termination
- Add a unit test and a patch changeset for `@hyperdx/otel-web-session-recorder` and `@hyperdx/browser`

Fixes #219. Same fix as upstream Splunk's signalfx/splunk-otel-js-web#1066. The `beforeunload` listener mentioned in the issue is left as is — it isn't deprecated, doesn't trigger the violation, and upstream keeps it.

## Testing

- `yarn ci:build` / `ci:lint` / `ci:unit` pass locally; new Jest tests cover listener registration and flush behavior
- Real-browser check (Chrome 151 headless, `--enable-features=DeprecateUnload`, OTLP collector + ClickHouse): the Permissions Policy violation is gone, events recorded just before leaving the page now arrive (previously dropped), and the page becomes bfcache-restorable (`pageshow.persisted === true`)
