### PR TITLE
fix(otel-web): decode only the requested cookie value

### DIFF
--- a/.changeset/fix-cookie-decode-uri-error.md
+++ b/.changeset/fix-cookie-decode-uri-error.md
@@ -1,0 +1,11 @@
+---
+'@hyperdx/otel-web': patch
+---
+
+Fix a `URIError: URI malformed` thrown from session tracking when the page has
+an unrelated cookie whose value is not percent-encoded. `findCookieValue` used
+to decode the entire `document.cookie` string before splitting it, so a single
+cookie containing a bare `%` (a legal cookie value) made every lookup throw.
+The error escaped `HyperDX.init()`, which could break host applications that
+initialize the SDK on their startup path. The value of the requested cookie is
+now decoded on its own. This ports the upstream fix from splunk-otel-js-web#962.

--- a/packages/otel-web/src/utils.ts
+++ b/packages/otel-web/src/utils.ts
@@ -47,12 +47,13 @@ export function generateId(bits: number): string {
 }
 
 export function findCookieValue(cookieName: string): string | undefined {
-  const decodedCookie = decodeURIComponent(document.cookie);
-  const cookies = decodedCookie.split(';');
+  const cookies = document.cookie.split(';');
   for (let i = 0; i < cookies.length; i++) {
     const c = cookies[i].trim();
     if (c.indexOf(cookieName + '=') === 0) {
-      return c.substring((cookieName + '=').length, c.length);
+      return decodeURIComponent(
+        c.substring((cookieName + '=').length, c.length),
+      );
     }
   }
   return undefined;

--- a/packages/otel-web/test/utils.test.ts
+++ b/packages/otel-web/test/utils.test.ts
@@ -28,7 +28,36 @@ describe('generateId', () => {
   });
 });
 describe('findCookieValue', () => {
+  const expireCookie = (name: string) => {
+    document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+  };
+
   it('should not find unset cookie', () => {
     assert.ok(findCookieValue('nosuchCookie') === undefined);
+  });
+
+  it('should decode the value of the requested cookie', () => {
+    document.cookie =
+      'testDecoded=' + encodeURIComponent('{"a":"b c"}') + ';path=/';
+    try {
+      assert.strictEqual(findCookieValue('testDecoded'), '{"a":"b c"}');
+    } finally {
+      expireCookie('testDecoded');
+    }
+  });
+
+  it('should not throw when an unrelated cookie is not percent-encoded', () => {
+    // Cookie values may legally contain a bare '%'. Decoding the whole
+    // document.cookie string made any such cookie throw a URIError here,
+    // which propagated out of session tracking and into the host page.
+    document.cookie = 'testMalformed=100%;path=/';
+    document.cookie = 'testNeighbour=' + encodeURIComponent('ok') + ';path=/';
+    try {
+      assert.strictEqual(findCookieValue('testNeighbour'), 'ok');
+      assert.ok(findCookieValue('nosuchCookie') === undefined);
+    } finally {
+      expireCookie('testMalformed');
+      expireCookie('testNeighbour');
+    }
   });
 });


### PR DESCRIPTION
## Description

`findCookieValue()` calls `decodeURIComponent()` on the **entire**
`document.cookie` string before splitting it:

```ts
const decodedCookie = decodeURIComponent(document.cookie);
const cookies = decodedCookie.split(';');
```

A cookie value may legally contain a bare `%` — it is not required to be
percent-encoded. So a single unrelated cookie set by anything else on the
domain (`foo=100%`, a truncated UTF-8 sequence, …) makes **every** lookup in
this function throw `URIError: URI malformed`.

Since session tracking calls this on init and again on every session refresh,
the error escapes `HyperDX.init()`. Applications that initialize the SDK on
their startup path — before mounting the app — get their bootstrap promise
rejected and never render:

```
Uncaught (in promise) URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at findCookieValue (...)
    at parseCookieToSessionState (...)
    at updateSessionStatus (...)
    at Object.init (...)      <- otel-web Rum.init
    at Object.init (...)      <- @hyperdx/browser HyperDX.init
    at startRum (...)         <- application code
```

We hit this in production: a blank page stuck on the loading state, and once
the SDK did start, the same `URIError` recurring every 60 s from the session
refresh timer.

## Fix

Split first, then decode only the value of the cookie that was asked for.

This is a direct port of the upstream fix in splunk-otel-js-web
([#962](https://github.com/signalfx/splunk-otel-js-web/pull/962), merged
2025-02-26), which never made it into this fork — same change, same shape,
including leaving the second `decodeURIComponent` in
`parseCookieToSessionState()` untouched.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Two unit tests added to `packages/otel-web/test/utils.test.ts`: one asserting
  the returned value is decoded, one asserting an unrelated non-encoded cookie
  no longer makes the lookup throw (the second one fails on `main`). Upstream
  landed the fix without tests; these cover it.
- Both assertions verified in headless Chrome against a real HTTP origin, along
  with a control showing `decodeURIComponent(document.cookie)` throwing
  `URIError` on the same cookie jar. I could not get the full Karma suite to
  start locally — its rollup TypeScript step needs `.d.ts` output from
  `@hyperdx/instrumentation-exception`, which my workspace build did not
  produce — so CI is the real check here.
- Reproduced originally against the production cookie jar that triggered it.
