### PR TITLE
fix(release): refresh yarn.lock during changeset version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ci:build": "npx nx run-many --targets=build,postbuild",
     "ci:unit": "npx nx run-many --target=ci:unit",
     "ci:lint": "npx nx run-many --target=ci:lint",
-    "version": "changeset version && npx nx run-many --target=postversion",
+    "version": "changeset version && yarn install --mode=update-lockfile && npx nx run-many --target=postversion",
     "release": "npx nx run-many --targets=build,postbuild && yarn changeset publish && git push --follow-tags",
     "release:next": "npx nx run-many --targets=build,postbuild && yarn changeset version --snapshot next && npx nx run-many --target=postversion && yarn changeset publish --tag next",
     "prepare": "husky install"


### PR DESCRIPTION
## Problem

Release PR #289 ("Version Packages") is red — **Unit** and **Install Check** both fail in `yarn install --immutable`:

```
YN0028: -    "@hyperdx/otel-web": "npm:0.19.0"
YN0028: +    "@hyperdx/otel-web": "npm:0.20.0"
YN0028: -    "@hyperdx/otel-web-session-recorder": "npm:3.0.0"
YN0028: +    "@hyperdx/otel-web-session-recorder": "npm:4.0.0"
YN0028: -    "@hyperdx/otel-web": ^0.19.0          # session-recorder peerDep
YN0028: +    "@hyperdx/otel-web": ^0.20.0
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

`changeset version` rewrites the internal `@hyperdx/*` cross-dependency ranges but never touches `yarn.lock`. Those ranges are literal npm versions rather than `workspace:` — `packages/browser` pins `"@hyperdx/otel-web": "0.19.0"` exactly, and `packages/session-recorder` peer-depends on `"^0.19.0"` — so `yarn.lock` encodes them and goes stale the instant a release PR is generated.

This isn't new to #289; it's newly *visible*. `3f1a32d` ("upgrade to Yarn 4 via Corepack") moved CI from bare `yarn` (Yarn 1, which silently rewrote the lockfile) to `yarn install --immutable`. #289 is the first release PR since. Every future one hits this too.

**It also blocks publishing, not just CI.** `.github/workflows/release.yaml:33` runs the same `yarn install --immutable`, so even a force-merged #289 would fail at install and never reach `changeset publish`.

## Fix

Refresh the lockfile as part of the `version` script. `--mode=update-lockfile` skips the link step and — as of Yarn 4.13.0 — bypasses the immutable check CI enables by default, so no `--no-immutable` is needed. `changesets/action` commits whatever `version` modifies, so the refreshed `yarn.lock` now lands in the release PR automatically.

`release:next` needs no change — nothing installs after its snapshot bump.

## Verification

Ran the real script locally against the four pending changesets:

```
$ CI=true yarn run version
  ➤ YN0073: │ Skipped due to mode=update-lockfile
  NX   Successfully ran target postversion for 2 projects

$ git diff yarn.lock          # exactly the 5 lines CI complained about
$ yarn install --immutable    # EXIT=0  ← previously YN0028
```

Also confirmed the failure reproduces without the fix (`yarn install --immutable` → `EXIT=1`), then reverted the simulated bump so this PR carries only the one-line script change.

## After merge

The push to `main` re-runs `release.yaml`, which regenerates `changeset-release/main` with an updated `yarn.lock`. #289 should go green and become mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)